### PR TITLE
add expires_in feature.

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/http/HttpUtil.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpUtil.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2016 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.http;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic HTTP utility class.
+ * 
+ * @author kmccrack
+ *
+ */
+public class HttpUtil {
+
+    /**
+     * Adds the specified name and value to the form parameters.
+     * If the value is non-null, the name and singleton-List of the value.toString() is 
+     * added to the formParams Map.
+     * 
+     * @param formParams the formParams Map, for use with application/x-www-form-urlencoded bodies
+     * @param name the name of the form parameter
+     * @param value the value of the form parameter
+     */
+    public static void addFormParam(Map<String, List<String>> formParams, String name, Object value) {
+        if (null != formParams && null != name && null != value) {
+            formParams.put(name, Collections.singletonList(value.toString()));
+        }
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenRequest.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenRequest.java
@@ -110,9 +110,9 @@ public abstract class AccessTokenRequest {
      * @return the JSON body, for use with application/json bodies
      */
     public String toJson() {
-        return "{\"" + GRANT_TYPE_JSON + "\":\"" + getGrantType()
+        return "{\"" + GRANT_TYPE_JSON + "\":\"" + getGrantType() + "\""
             + (null != expiresIn ? ",\"" + EXPIRES_IN_JSON + "\":" + expiresIn : "")
-            + "\"}";
+            + "}";
     }
 
     /**

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ClientCredentialsGrantRequest.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ClientCredentialsGrantRequest.java
@@ -33,7 +33,7 @@ public class ClientCredentialsGrantRequest extends AccessTokenRequest {
      * {@inheritDoc}
      */
     @Override
-    public AccessTokenRequest setExpiresIn(Long expiresIn) {
+    public ClientCredentialsGrantRequest setExpiresIn(Long expiresIn) {
         super.setExpiresIn(expiresIn);
         return this;
     }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ClientCredentialsGrantRequest.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ClientCredentialsGrantRequest.java
@@ -15,10 +15,6 @@
  */
 package com.here.account.oauth2;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
 /**
  * An {@link AccessTokenRequest} for grant_type=client_credentials.
  * 
@@ -27,24 +23,19 @@ import java.util.Map;
  */
 public class ClientCredentialsGrantRequest extends AccessTokenRequest {
     
-    public ClientCredentialsGrantRequest() {
-        super("client_credentials");
-    }
+    public static final String CLIENT_CREDENTIALS_GRANT_TYPE = "client_credentials";
     
+    public ClientCredentialsGrantRequest() {
+        super(CLIENT_CREDENTIALS_GRANT_TYPE);
+    }
+
     /**
      * {@inheritDoc}
      */
     @Override
-    public String toJson() {
-        return "{\"grantType\":\"" + getGrantType()
-            + "\"}";
+    public AccessTokenRequest setExpiresIn(Long expiresIn) {
+        super.setExpiresIn(expiresIn);
+        return this;
     }
-
-    @Override
-    public Map<String, List<String>> toFormParams() {
-        Map<String, List<String>> formParams = new HashMap<String, List<String>>();
-        addFormParam(formParams, "grant_type", getGrantType());
-        return formParams;
-    }
-
+    
 }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ErrorResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ErrorResponse.java
@@ -15,10 +15,6 @@
  */
 package com.here.account.oauth2;
 
-/* Example:
-com.here.account.AccessTokenException: HTTP status code 401, body 
-{"errorId":"ERROR-905ffdd8-34b1-4fc7-ba98-775206d292f9","httpStatus":401,"hereErrorCode":401400,"errorCode":401400,"message":"Invalid Credentials for user:test4312@example.com"}
- */
 /**
  * The POJO representation of an OAuth2.0 HERE authorization server error response.
  * See also the 
@@ -81,35 +77,56 @@ public class ErrorResponse {
      * 
      */
     private final String error;
-
-    /**
-     * A unique error identifier, useful for support questions, 
-     * or tracking purposes.
-     */
-    private final String errorId;
     
     /**
      * The numeric HTTP status code.
      * See also the HTTP 
      * <a href="https://tools.ietf.org/html/rfc7231#section-6">Response Status Codes</a> 
      * section.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
      */
     private final Integer httpStatus;
     
     /**
+     * A unique error identifier, useful for support questions, 
+     * or tracking purposes.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
+     */
+    private final String errorId;
+    
+    /**
      * A more detailed categorized code for the error, specific to the HERE authorization server 
      * semantics.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
      */
     private final Integer errorCode;
     
     /**
      * A potentially-human-readable message describing the error.
      * No machine or automated code should process or interpret this value.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
      */
     private final String message;
     
     public ErrorResponse() {
-        this(null, null, null, null, null);
+        this(null);
+    }
+    
+    public ErrorResponse(
+            String error) {
+        this.error = error;
+        this.errorId = null;
+        this.httpStatus = null;
+        this.errorCode = null;
+        this.message = null;
     }
     
     public ErrorResponse(String error, 
@@ -118,8 +135,8 @@ public class ErrorResponse {
           Integer errorCode,
           String message) {
         this.error = error;
-        this.errorId = errorId;
         this.httpStatus = httpStatus;
+        this.errorId = errorId;
         this.errorCode = errorCode;
         this.message = message;
     }
@@ -178,24 +195,16 @@ public class ErrorResponse {
     public String getError() {
         return error;
     }
-
+    
     /**
-     * the errorId.
-     * A unique error identifier, useful for support questions, 
-     * or tracking purposes.
-     * 
-     * @return the errorId
-     */
-    public String getErrorId() {
-        return errorId;
-    }
-
-    /**
-     * the httpStatus.
+     * The httpStatus.
      * The numeric HTTP status code.
      * See also the HTTP 
      * <a href="https://tools.ietf.org/html/rfc7231#section-6">Response Status Codes</a> 
      * section.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
      * 
      * @return the httpStatus
      */
@@ -204,10 +213,27 @@ public class ErrorResponse {
     }
 
     /**
-     * the errorCode.
+     * The errorId.
+     * A unique error identifier, useful for support questions, 
+     * or tracking purposes.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
+     * 
+     * @return the errorId
+     */
+    public String getErrorId() {
+        return errorId;
+    }
+
+    /**
+     * The errorCode.
      * A more detailed categorized code for the error, specific to the HERE authorization server 
      * semantics.
      * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
+     *
      * @return the errorCode
      */
     public Integer getErrorCode() {
@@ -215,9 +241,12 @@ public class ErrorResponse {
     }
 
     /**
-     * the message.
+     * The message.
      * A potentially-human-readable message describing the error.
      * No machine or automated code should process or interpret this value.
+     * 
+     * <p>
+     * This property is a HERE extension to RFC6749 providing additional data.
      * 
      * @return the message
      */
@@ -225,10 +254,12 @@ public class ErrorResponse {
         return message;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String toString() {
-        return "ErrorResponse [errorId=" + errorId + ", httpStatus=" + httpStatus + ", errorCode=" + errorCode
-                + ", message=" + message + "]";
+        return "ErrorResponse [error=" + error + "]";
     }
         
 }

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/AbstractCredentialTezt.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/AbstractCredentialTezt.java
@@ -53,9 +53,9 @@ public abstract class AbstractCredentialTezt {
         return "~" + File.separatorChar + DOT_HERE_SUBDIR + File.separatorChar + CREDENTIALS_DOT_PROPERTIES_FILENAME;
     }
     
-    String url;
-    String accessKeyId;
-    String accessKeySecret;
+    protected String url;
+    protected String accessKeyId;
+    protected String accessKeySecret;
     
     @Before
     public void setUp() throws Exception {

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/ClientCredentialsGrantRequestTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/ClientCredentialsGrantRequestTest.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+
+import com.here.account.util.JsonSerializer;
+import com.here.account.util.OAuthConstants;
+
+public class ClientCredentialsGrantRequestTest {
+
+    @Test
+    public void test_ClientCredentialsGrantRequest_json() {
+        ClientCredentialsGrantRequest clientCredentialsGrantRequest = new ClientCredentialsGrantRequest();
+        String json = clientCredentialsGrantRequest.toJson();
+        String expectedJson = "{\"grantType\":\"client_credentials\"}";
+        assertTrue("expected json "+expectedJson+", actual "+json, expectedJson.equals(json));
+    }
+    
+    @Test
+    public void test_ClientCredentialsGrantRequest_json_expiresIn() throws IOException {
+        long expiresIn = 15;
+        ClientCredentialsGrantRequest clientCredentialsGrantRequest = new ClientCredentialsGrantRequest().setExpiresIn(expiresIn);
+        String json = clientCredentialsGrantRequest.toJson();
+        String expectedJson = "{\"grantType\":\"client_credentials\",\"expiresIn\":"+expiresIn+"}";
+        Map<String, Object> jsonMap = toMap(json);
+        Map<String, Object> expectedMap = toMap(expectedJson);
+        assertTrue("expected json "+expectedMap+", actual "+jsonMap, expectedMap.equals(jsonMap));
+    }
+    
+    @Test
+    public void test_ClientCredentialsGrantRequest_form() {
+        ClientCredentialsGrantRequest clientCredentialsGrantRequest = new ClientCredentialsGrantRequest();
+        Map<String, List<String>> form = clientCredentialsGrantRequest.toFormParams();
+        Map<String, List<String>> expectedForm = new HashMap<String, List<String>>();
+        expectedForm.put("grant_type", Collections.singletonList("client_credentials"));
+        assertTrue("expected form "+expectedForm+", actual "+form, expectedForm.equals(form));
+    }
+    
+    @Test
+    public void test_ClientCredentialsGrantRequest_form_expiresIn() throws IOException {
+        long expiresIn = 15;
+        ClientCredentialsGrantRequest clientCredentialsGrantRequest = new ClientCredentialsGrantRequest().setExpiresIn(expiresIn);
+        Map<String, List<String>> form = clientCredentialsGrantRequest.toFormParams();
+        Map<String, List<String>> expectedForm = new HashMap<String, List<String>>();
+        expectedForm.put("grant_type", Collections.singletonList("client_credentials"));
+        expectedForm.put("expires_in", Collections.singletonList(""+expiresIn));
+        assertTrue("expected form "+expectedForm+", actual "+form, expectedForm.equals(form));
+    }
+
+
+    private Map<String, Object> toMap(String json) throws IOException {
+        byte[] bytes = json.getBytes(OAuthConstants.UTF_8_CHARSET);
+        ByteArrayInputStream jsonInputStream = null;
+        try {
+            jsonInputStream = new ByteArrayInputStream(bytes);
+            return JsonSerializer.toMap(jsonInputStream);
+        } finally {
+            if (null != jsonInputStream) {
+                jsonInputStream.close();
+            }
+        }
+    }
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/SignInWithClientCredentialsTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/SignInWithClientCredentialsTest.java
@@ -15,6 +15,7 @@
  */
 package com.here.account.oauth2;
 
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 
@@ -26,7 +27,6 @@ import com.here.account.auth.OAuth1ClientCredentialsProvider;
 import com.here.account.http.HttpConstants;
 import com.here.account.http.HttpProvider;
 import com.here.account.http.apache.ApacheHttpClientProvider;
-import static org.junit.Assert.assertTrue;
 
 public class SignInWithClientCredentialsTest extends AbstractCredentialTezt {
 
@@ -79,4 +79,31 @@ public class SignInWithClientCredentialsTest extends AbstractCredentialTezt {
         }
 
     }
+    
+    @Test
+    public void test_signIn_expiresIn() throws Exception {
+        AccessTokenResponse accessTokenResponse = signIn.requestToken(new ClientCredentialsGrantRequest());
+        String hereAccessToken = accessTokenResponse.getAccessToken();
+        assertTrue("hereAccessToken was null or blank", 
+                null != hereAccessToken && hereAccessToken.length() > 0);
+        
+        AccessTokenResponse accessTokenResponse15 = signIn.requestToken(new ClientCredentialsGrantRequest().setExpiresIn(15L));
+        String hereAccessToken15 = accessTokenResponse15.getAccessToken();
+        assertTrue("hereAccessToken15 was null or blank", 
+                null != hereAccessToken15 && hereAccessToken15.length() > 0);
+    
+        long expiresIn = accessTokenResponse.getExpiresIn();
+        long expiresIn15 = accessTokenResponse15.getExpiresIn();
+        assertTrue("expiresIn15 "+expiresIn15+" !< expiresIn "+expiresIn, 
+                expiresIn15 < expiresIn);
+        
+        // Verification adds some tolerance to the exact number of seconds.
+        // The server should not think it's valid longer than 15 seconds.
+        // The client should have been successful telling the server this, 
+        // and the client should be able to deserialize the response properly 
+        // for this constraint to hold.
+        assertTrue("expiresIn15 "+expiresIn15+" not in range",
+                1 <= expiresIn15 && expiresIn15 <= 15);
+    }
+    
 }


### PR DESCRIPTION
Optionally set the lifetime in seconds of the access token returned by 
this request.
Must be a positive number.  Ignored if greater than the maximum expiration 
for the client application.
Typically you can set this from 1 to 86400, the latter representing 24 
hours.