### PR TITLE
Error responses

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
@@ -72,7 +72,7 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
     }
     
     /**
-     * Construct the OAuth signer based on clock, clientId, and clientSecret.
+     * Construct the OAuth signer based on clock, accessKeyId, and accessKeySecret.
      * Use this if you want to inject your own clock, such as during unit tests.
      * 
      * @param clock the implementation of a clock you want to use
@@ -81,7 +81,7 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
      * @param accessKeySecret the HERE clientSecret.  Used to calculate the oauth_signature 
      *      in the Authorization: OAuth header.
      */
-    OAuth1Signer(Clock clock, String accessKeyId, String accessKeySecret) {
+    public OAuth1Signer(Clock clock, String accessKeyId, String accessKeySecret) {
         this.clock = clock;
         this.accessKeyId = accessKeyId;
         this.accessKeySecret = accessKeySecret;

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ErrorResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ErrorResponse.java
@@ -15,6 +15,8 @@
  */
 package com.here.account.oauth2;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 /**
  * The POJO representation of an OAuth2.0 HERE authorization server error response.
  * See also the 
@@ -79,6 +81,20 @@ public class ErrorResponse {
     private final String error;
     
     /**
+     * The error_description value.
+     * From OAuth2.0 <a href="https://tools.ietf.org/html/rfc6749#section-5.2">Error Response</a> 
+     * section, the following parameter: 
+     * error_description
+         OPTIONAL.  Human-readable ASCII [USASCII] text providing
+         additional information, used to assist the client developer in
+         understanding the error that occurred.
+         Values for the "error_description" parameter MUST NOT include
+         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+     */
+    @JsonProperty("error_description")
+    private final String errorDescription;
+    
+    /**
      * The numeric HTTP status code.
      * See also the HTTP 
      * <a href="https://tools.ietf.org/html/rfc7231#section-6">Response Status Codes</a> 
@@ -117,15 +133,17 @@ public class ErrorResponse {
     private final String message;
     
     public ErrorResponse() {
-        this(null, null, null, null, null);
+        this(null, null, null, null, null, null);
     }
     
     public ErrorResponse(String error, 
+            String errorDescription,
           String errorId,
           Integer httpStatus,
           Integer errorCode,
           String message) {
         this.error = error;
+        this.errorDescription = errorDescription;
         this.httpStatus = httpStatus;
         this.errorId = errorId;
         this.errorCode = errorCode;
@@ -185,6 +203,23 @@ public class ErrorResponse {
      */
     public String getError() {
         return error;
+    }
+
+    /**
+     * The error_description value.
+     * From OAuth2.0 <a href="https://tools.ietf.org/html/rfc6749#section-5.2">Error Response</a> 
+     * section, the following parameter: 
+     * error_description
+         OPTIONAL.  Human-readable ASCII [USASCII] text providing
+         additional information, used to assist the client developer in
+         understanding the error that occurred.
+         Values for the "error_description" parameter MUST NOT include
+         characters outside the set %x20-21 / %x23-5B / %x5D-7E.
+     * 
+     * @return the error description
+     */
+    public String getErrorDescription() {
+        return errorDescription;
     }
     
     /**
@@ -250,7 +285,8 @@ public class ErrorResponse {
      */
     @Override
     public String toString() {
-        return "ErrorResponse [error=" + error + "]";
+        return "ErrorResponse [error=" + error + ", errorDescription=" + errorDescription + ", httpStatus=" + httpStatus
+                + ", errorId=" + errorId + ", errorCode=" + errorCode + ", message=" + message + "]";
     }
         
 }

--- a/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
@@ -44,8 +44,8 @@ import com.here.account.util.OAuthConstants;
 
 public class OAuth1SignerTest {
 
-    private String clientId = "clientId";
-    private String clientSecret = "clientSecret";
+    private String accessKeyId = "access-key-id";
+    private String accessKeySecret = "access-key-secret";
     
     private OAuth1Signer oauth1Signer;
     
@@ -97,15 +97,15 @@ public class OAuth1SignerTest {
             }
             
         };
-        this.oauth1Signer = new MyOAuth1Signer(clock, clientId, clientSecret);
+        this.oauth1Signer = new MyOAuth1Signer(clock, accessKeyId, accessKeySecret);
         this.httpRequest = new MyHttpRequest();
         this.method = "GET";
         this.url = "http://localhost:8080/whatever";
     }
     
     protected static class MyOAuth1Signer extends OAuth1Signer {
-        public MyOAuth1Signer(Clock clock, String clientId, String clientSecret) {
-            super(clock, clientId, clientSecret);
+        public MyOAuth1Signer(Clock clock, String accessKeyId, String accessKeySecret) {
+            super(clock, accessKeyId, accessKeySecret);
         }
 
         /**
@@ -197,7 +197,7 @@ public class OAuth1SignerTest {
 
         String shaVariant = "SHA256";//"SHA1";
         
-        String requestParameters = "oauth_consumer_key="+clientId+"&oauth_nonce="+nonce+"&oauth_signature_method=HMAC-"+shaVariant+"&oauth_timestamp="+oauth_timestamp+"&oauth_version=1.0";
+        String requestParameters = "oauth_consumer_key="+accessKeyId+"&oauth_nonce="+nonce+"&oauth_signature_method=HMAC-"+shaVariant+"&oauth_timestamp="+oauth_timestamp+"&oauth_version=1.0";
         String signatureBaseString = "GET&"
                 +urlEncode(url)+"&"
                 + urlEncode(requestParameters); // no request parameters in this test case
@@ -205,7 +205,7 @@ public class OAuth1SignerTest {
 
         System.out.println("test       signatureBaseString "+signatureBaseString);
         
-        String key = urlEncode(clientSecret) + "&"; // no token shared-secret
+        String key = urlEncode(accessKeySecret) + "&"; // no token shared-secret
         
         String expectedSignature = HmacSHAN(key, "Hmac"+shaVariant, signatureBaseString);
 

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccountTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccountTest.java
@@ -27,6 +27,7 @@ import java.util.List;
 import java.util.Map;
 
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.mockito.stubbing.OngoingStubbing;
@@ -49,6 +50,7 @@ public class HereAccountTest extends AbstractCredentialTezt {
      * @throws ResponseParsingException
      */
     @Test(expected=FileNotFoundException.class) 
+    @SuppressWarnings("unused") // code snippet from Javadocs verbatim; intentionally has unused variable
     public void test_simpleUseCase_javadocs() throws IOException, AccessTokenException, RequestExecutionException, ResponseParsingException {
         // use your provided credentials.properties
         TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
@@ -61,6 +63,7 @@ public class HereAccountTest extends AbstractCredentialTezt {
     }
 
     @Test
+    @SuppressWarnings("unused") // code snippet from Javadocs verbatim; intentionally has unused variable
     public void test_getSignIn_javadocs() throws AccessTokenException, RequestExecutionException, ResponseParsingException {
         // set up url, accessKeyId, and accessKeySecret.
         TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
@@ -73,6 +76,7 @@ public class HereAccountTest extends AbstractCredentialTezt {
     }
     
     @Test
+    @SuppressWarnings("unused") // code snippet from Javadocs verbatim; intentionally has unused variable
     public void test_getRefreshableClientAuthorizationProvider_javadocs() throws AccessTokenException, RequestExecutionException, ResponseParsingException {
         // set up url, accessKeyId, and accessKeySecret.
         TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
@@ -100,6 +104,7 @@ public class HereAccountTest extends AbstractCredentialTezt {
      * @throws IOException
      */
     @Test(expected=FileNotFoundException.class) 
+    @SuppressWarnings("unused") // code snippet from Javadocs verbatim; intentionally has unused variable
     public void test_file_javadocs() throws IOException {
         // setup url, accessKeyId, and accessKeySecret as properties in credentials.properties
         TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
@@ -185,6 +190,7 @@ public class HereAccountTest extends AbstractCredentialTezt {
      * @throws Exception if an unexpected Exception is thrown by the test.
      */
     @Test
+    @Ignore // TODO: un-Ignore.  integration test fails for now, needs server-side fix to re-activate
     public void testGetToken_MissingRequiredParameter() throws Exception {
         TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
                 ApacheHttpClientProvider.builder().build(), 


### PR DESCRIPTION
ErrorResponse: add support for error_description from OAuth2 Spec.
Add tests with breaking clock skew.
Add more details to toString().
Variable renaming to newer convention in tests.
Suppress warnings for intentionally unused variables in tests.
@Ignore failing negative integration test case until server-side is patched.
