### PR TITLE
Improve SCM meta-data in the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,9 @@
     </developers>
 
     <scm>
-      <connection>scm:git:git://github.com/heremaps/here-aaa-java-sdk.git</connection>
-      <developerConnection>scm:git:ssh://github.com:heremaps/here-aaa-java-sdk.git</developerConnection>
-      <url>http://github.com/heremaps/here-aaa-java-sdk/tree/master</url>
+      <connection>scm:git:https://github.com/heremaps/here-aaa-java-sdk.git</connection>
+      <developerConnection>scm:git:git@github.com:heremaps/here-aaa-java-sdk.git</developerConnection>
+      <url>https://github.com/heremaps/here-aaa-java-sdk</url>
     </scm>
 
     <modules>


### PR DESCRIPTION
- The standard read-only connection URL on GitHub is HTTPS, not the Git protocol.
- Fix the SSH URL to contain the required generic "git" user name.
- The browsable URL should not hard-code the default branch name.