### PR TITLE
Allow creation of ApacheHttpClientProviders without builder to include custom settings (e.g. proxy)

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -324,7 +324,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
     private final CloseableHttpClient httpClient;
     private final boolean doCloseHttpClient;
 
-    private ApacheHttpClientProvider(CloseableHttpClient httpClient, boolean doCloseHttpClient) {
+    public ApacheHttpClientProvider(CloseableHttpClient httpClient, boolean doCloseHttpClient) {
         this.httpClient = httpClient;
         this.doCloseHttpClient = doCloseHttpClient;
     }

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -51,20 +51,17 @@ import com.here.account.http.HttpException;
 import com.here.account.http.HttpProvider;
 
 /**
- * An {@link HttpProvider} that uses Apache HttpClient as the underlying
- * implementation. See
- * <a href="https://hc.apache.org/httpcomponents-client-ga/">Apache HTTP
- * Components</a> for more information, specifically the HttpClient project.
+ * An {@link HttpProvider} that uses Apache HttpClient as the underlying implementation.
+ * See <a href="https://hc.apache.org/httpcomponents-client-ga/">Apache HTTP Components</a> 
+ * for more information, specifically the HttpClient project.
  * 
  * <p>
- * If you just want the default 5000 ms for both connection timeout and request
- * timeout, just use the following example code:
- * 
+ * If you just want the default 5000 ms for both connection timeout and request timeout, 
+ * just use the following example code:
  * <pre>
- * {
- *     @code
- *     HttpProvider httpProvider = ApacheHttpClientProvider.builder().build();
- *     // use httpProvider such as with HereAccessTokenProviders...
+ * {@code
+       HttpProvider httpProvider = ApacheHttpClientProvider.builder().build();
+       // use httpProvider such as with HereAccessTokenProviders...
  * }
  * </pre>
  * 
@@ -218,14 +215,24 @@ public class ApacheHttpClientProvider implements HttpProvider {
         }
 
         /*
-         * // headers support String contentType = null; FluentCaseInsensitiveStringsMap
-         * headers = request.getHeaders(); if (null != headers) { for (Entry<String,
-         * List<String>> entry : headers.entrySet()) { String name = entry.getKey();
-         * List<String> valueList = entry.getValue(); if (null != name && null !=
-         * valueList && valueList.size() > 0) { for (String value : valueList) { if
-         * (null == contentType && name.equals(AbstractHttpRequest.CONTENT_TYPE)) {
-         * contentType = value; } apacheRequest.addHeader(name, value); } } } }
-         */
+        // headers support
+        String contentType = null;
+        FluentCaseInsensitiveStringsMap headers = request.getHeaders();
+        if (null != headers) {
+            for (Entry<String, List<String>> entry : headers.entrySet()) {
+                String name = entry.getKey();
+                List<String> valueList = entry.getValue();
+                if (null != name && null != valueList && valueList.size() > 0) {
+                    for (String value : valueList) {
+                        if (null == contentType && name.equals(AbstractHttpRequest.CONTENT_TYPE)) {
+                            contentType = value;
+                        }
+                        apacheRequest.addHeader(name, value);
+                    }
+                }
+            }
+        }
+        */
 
         return apacheRequest;
     }

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -123,13 +123,13 @@ public class ApacheHttpClientProvider implements HttpProvider {
     }
 
     private static class ApacheHttpClientRequest implements HttpRequest {
-
+        
         private final HttpRequestBase httpRequestBase;
-
+        
         private ApacheHttpClientRequest(HttpRequestBase httpRequestBase) {
             this.httpRequestBase = httpRequestBase;
         }
-
+        
         private HttpRequestBase getHttpRequestBase() {
             return httpRequestBase;
         }
@@ -142,15 +142,15 @@ public class ApacheHttpClientProvider implements HttpProvider {
             httpRequestBase.addHeader(HttpConstants.AUTHORIZATION_HEADER, value);
         }
     }
-
+    
     private static class ApacheHttpClientResponse implements HttpResponse {
-
+        
         private final org.apache.http.HttpResponse apacheHttpResponse;
-
+        
         private ApacheHttpClientResponse(org.apache.http.HttpResponse apacheHttpResponse) {
             this.apacheHttpResponse = apacheHttpResponse;
         }
-
+        
         /**
          * {@inheritDoc}
          */
@@ -170,7 +170,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
             }
             return null;
         }
-
+        
         /**
          * {@inheritDoc}
          */
@@ -185,8 +185,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
 
     }
 
-    private HttpRequestBase getRequestNoAuth(String method, String url, String requestBodyJson,
-            Map<String, List<String>> formParams) {
+    private HttpRequestBase getRequestNoAuth(String method, String url) {
         URI uri;
         try {
             uri = new URI(url);
@@ -213,7 +212,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
         } else {
             throw new IllegalArgumentException("no support for request method=" + method);
         }
-
+            
         /*
         // headers support
         String contentType = null;
@@ -233,25 +232,27 @@ public class ApacheHttpClientProvider implements HttpProvider {
             }
         }
         */
-
+        
         return apacheRequest;
     }
-
-    private void addApacheRequestEntity(HttpRequestBase apacheRequest, String method, String requestBodyJson,
+    
+    private void addApacheRequestEntity(HttpRequestBase apacheRequest, 
+            String method,
+            String requestBodyJson,
             Map<String, List<String>> formParams) {
-        HttpEntityEnclosingRequestBase apacheRequestSupportsEntity = apacheRequest instanceof HttpEntityEnclosingRequestBase
-                ? (HttpEntityEnclosingRequestBase) apacheRequest
-                : null;
+        HttpEntityEnclosingRequestBase apacheRequestSupportsEntity = 
+                apacheRequest instanceof HttpEntityEnclosingRequestBase 
+                ? (HttpEntityEnclosingRequestBase) apacheRequest 
+                        : null;
 
         // body support
         if (null != formParams && formParams.size() > 0) {
             if (null == apacheRequestSupportsEntity) {
-                throw new IllegalArgumentException("no formParams permitted for method " + method);
+                throw new IllegalArgumentException("no formParams permitted for method "+method);
             }
             // form parameters support
             // application/x-www-form-urlencoded only
-            apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE,
-                    HttpConstants.CONTENT_TYPE_FORM_URLENCODED);
+            apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_FORM_URLENCODED);
             List<NameValuePair> parameters = new ArrayList<NameValuePair>();
             for (Entry<String, List<String>> entry : formParams.entrySet()) {
                 String key = entry.getKey();
@@ -268,7 +269,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
             apacheRequestSupportsEntity.setEntity(entity);
         } else if (null != requestBodyJson) {
             if (null == apacheRequestSupportsEntity) {
-                throw new IllegalArgumentException("no JSON request body permitted for method " + method);
+                throw new IllegalArgumentException("no JSON request body permitted for method "+method);
             }
             // JSON body support
             apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JSON);
@@ -282,56 +283,49 @@ public class ApacheHttpClientProvider implements HttpProvider {
         }
 
     }
-
+    
     /**
      * {@inheritDoc}
      */
     @Override
     public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
             String requestBodyJson) {
-        HttpRequestBase apacheRequest =
-                /*
-                 * String method, String url, String requestBodyJson, Map<String, List<String>>
-                 * formParams
-                 */
-                getRequestNoAuth(method, url, requestBodyJson, null);
-
+        HttpRequestBase apacheRequest = 
+                /*String method, String url*/
+                getRequestNoAuth(method, url);
+        
         ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
-
+        
         // OAuth1
-        // NOTE: because this example uses application/json, not forms, our request
-        // bodies are
+        // NOTE: because this example uses application/json, not forms, our request bodies are 
         // never part of the OAuth1 Authorization header.
         Map<String, List<String>> formParams = null;
         httpRequestAuthorizer.authorize(request, method, url, formParams);
 
         addApacheRequestEntity(apacheRequest, method, requestBodyJson, null);
-
+        
         return request;
     }
-
+    
     /**
      * {@inheritDoc}
      */
     @Override
     public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
             Map<String, List<String>> formParams) {
-        HttpRequestBase apacheRequest =
-                /*
-                 * String method, String url, String requestBodyJson, Map<String, List<String>>
-                 * formParams
-                 */
-                getRequestNoAuth(method, url, null, formParams);
-
+        HttpRequestBase apacheRequest = 
+                /*String method, String url*/
+                getRequestNoAuth(method, url);
+        
         ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
-
+        
         // OAuth1
-        // with application/x-www-form-urlencoded bodies,
+        // with application/x-www-form-urlencoded bodies, 
         // the request body is supposed to impact the signature.
         httpRequestAuthorizer.authorize(request, method, url, formParams);
 
         addApacheRequestEntity(apacheRequest, method, null, formParams);
-
+        
         return request;
     }
 
@@ -342,7 +336,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
         this.httpClient = httpClient;
         this.doCloseHttpClient = doCloseHttpClient;
     }
-
+    
     /**
      * {@inheritDoc}
      */
@@ -353,21 +347,22 @@ public class ApacheHttpClientProvider implements HttpProvider {
         }
     }
 
+
     @Override
     public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
         if (!(httpRequest instanceof ApacheHttpClientRequest)) {
-            throw new IllegalArgumentException("httpRequest is not of expected type; use " + getClass()
-                    + ".getRequest(..) to get a request of the expected type");
+            throw new IllegalArgumentException("httpRequest is not of expected type; use "
+                    +getClass()+".getRequest(..) to get a request of the expected type");
         }
         HttpRequestBase httpRequestBase = ((ApacheHttpClientRequest) httpRequest).getHttpRequestBase();
-
+        
         // we are stateless
         HttpContext httpContext = null;
-
+        
         try {
             // blocking
             org.apache.http.HttpResponse apacheHttpResponse = httpClient.execute(httpRequestBase, httpContext);
-
+            
             return new ApacheHttpClientResponse(apacheHttpResponse);
         } catch (ClientProtocolException e) {
             throw new HttpException("trouble: " + e, e);

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -51,17 +51,20 @@ import com.here.account.http.HttpException;
 import com.here.account.http.HttpProvider;
 
 /**
- * An {@link HttpProvider} that uses Apache HttpClient as the underlying implementation.
- * See <a href="https://hc.apache.org/httpcomponents-client-ga/">Apache HTTP Components</a> 
- * for more information, specifically the HttpClient project.
+ * An {@link HttpProvider} that uses Apache HttpClient as the underlying
+ * implementation. See
+ * <a href="https://hc.apache.org/httpcomponents-client-ga/">Apache HTTP
+ * Components</a> for more information, specifically the HttpClient project.
  * 
  * <p>
- * If you just want the default 5000 ms for both connection timeout and request timeout, 
- * just use the following example code:
+ * If you just want the default 5000 ms for both connection timeout and request
+ * timeout, just use the following example code:
+ * 
  * <pre>
- * {@code
-       HttpProvider httpProvider = ApacheHttpClientProvider.builder().build();
-       // use httpProvider such as with HereAccessTokenProviders...
+ * {
+ * 	&#64;code
+ * 	HttpProvider httpProvider = ApacheHttpClientProvider.builder().build();
+ * 	// use httpProvider such as with HereAccessTokenProviders...
  * }
  * </pre>
  * 
@@ -69,296 +72,299 @@ import com.here.account.http.HttpProvider;
  *
  */
 public class ApacheHttpClientProvider implements HttpProvider {
-    
-    public static Builder builder() {
-        return new Builder();
-    }
 
-    public static class Builder {
-        private RequestConfig.Builder apacheConfigBuilder;
-    
-        private Builder() {
-            apacheConfigBuilder = RequestConfig.custom();
-            setConnectionTimeoutInMs(HttpConstants.DEFAULT_CONNECTION_TIMEOUT_IN_MS);
-            setRequestTimeoutInMs(HttpConstants.DEFAULT_REQUEST_TIMEOUT_IN_MS);
-        }
-    
-        public Builder setConnectionTimeoutInMs(int connectionTimeoutInMs) {
-            this.apacheConfigBuilder
-                .setConnectTimeout(connectionTimeoutInMs)
-                .setConnectionRequestTimeout(connectionTimeoutInMs);
-            return this;
-        }
-    
-        public Builder setRequestTimeoutInMs(int requestTimeoutInMs) {
-            this.apacheConfigBuilder
-                .setSocketTimeout(requestTimeoutInMs);
-            return this;
-        }
-    
-        /**
-         * Build using builders, builders, and more builders.
-         * 
-         * @return the built HttpProvider implementation for Apache httpclient.
-         */
-        public HttpProvider build() {
-            // uses PoolingHttpClientConnectionManager by default
-            return new ApacheHttpClientProvider(HttpClientBuilder.create()
-                    .setDefaultRequestConfig(apacheConfigBuilder
-                            .build())
-                    .build(), true);
-    
-        }
-    }
+	public static Builder builder() {
+		return new Builder();
+	}
 
-    private static class ApacheHttpClientRequest implements HttpRequest {
-        
-        private final HttpRequestBase httpRequestBase;
-        
-        private ApacheHttpClientRequest(HttpRequestBase httpRequestBase) {
-            this.httpRequestBase = httpRequestBase;
-        }
-        
-        private HttpRequestBase getHttpRequestBase() {
-            return httpRequestBase;
-        }
+	public static class Builder {
+		private RequestConfig.Builder apacheConfigBuilder;
+		private CloseableHttpClient httpClient;
+		private boolean doCloseHttpClient = true;
 
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public void addAuthorizationHeader(String value) {
-            httpRequestBase.addHeader(HttpConstants.AUTHORIZATION_HEADER, value);
-        }
-    }
-    
-    private static class ApacheHttpClientResponse implements HttpResponse {
-        
-        private final org.apache.http.HttpResponse apacheHttpResponse;
-        
-        private ApacheHttpClientResponse(org.apache.http.HttpResponse apacheHttpResponse) {
-            this.apacheHttpResponse = apacheHttpResponse;
-        }
-        
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public int getStatusCode() {
-            return apacheHttpResponse.getStatusLine().getStatusCode();
-        }
+		private Builder() {
+			apacheConfigBuilder = RequestConfig.custom();
+			setConnectionTimeoutInMs(HttpConstants.DEFAULT_CONNECTION_TIMEOUT_IN_MS);
+			setRequestTimeoutInMs(HttpConstants.DEFAULT_REQUEST_TIMEOUT_IN_MS);
+		}
 
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public InputStream getResponseBody() throws IOException {
-            HttpEntity httpEntity = apacheHttpResponse.getEntity();
-            if (null != httpEntity) {
-                return httpEntity.getContent();
-            }
-            return null;
-        }
-        
-        /**
-         * {@inheritDoc}
-         */
-        @Override
-        public long getContentLength() {
-            HttpEntity httpEntity = apacheHttpResponse.getEntity();
-            if (null != httpEntity) {
-                return httpEntity.getContentLength();
-            }
-            return 0L;
-        }
+		public Builder setHttpClient(final CloseableHttpClient httpClient) {
+			this.httpClient = httpClient;
+			return this;
+		}
 
-    }
+		public Builder setDoCloseHttpClient(final boolean doCloseHttpClient) {
+			this.doCloseHttpClient = doCloseHttpClient;
+			return this;
+		}
 
-    private HttpRequestBase getRequestNoAuth(String method, String url, 
-            String requestBodyJson, Map<String, List<String>> formParams) {
-        URI uri;
-        try {
-            uri = new URI(url);
-        } catch (URISyntaxException e) {
-            throw new IllegalArgumentException("malformed URL: " + e, e);
-        }
-        HttpRequestBase apacheRequest = null;
-        if (method.equals(HttpGet.METHOD_NAME)) {
-            apacheRequest = new HttpGet(uri);
-        } else if (method.equals(HttpPost.METHOD_NAME)) {
-            apacheRequest = new HttpPost(uri);
-        } else if (method.equals(HttpPut.METHOD_NAME)) {
-            apacheRequest = new HttpPut(uri);
-        } else if (method.equals(HttpDelete.METHOD_NAME)) {
-            apacheRequest = new HttpDelete(uri);
-        } else if (method.equals(HttpHead.METHOD_NAME)) {
-            apacheRequest = new HttpHead(uri);
-        } else if (method.equals(HttpOptions.METHOD_NAME)) {
-            apacheRequest = new HttpOptions(uri);
-        } else if (method.equals(HttpTrace.METHOD_NAME)) {
-            apacheRequest = new HttpTrace(uri);
-        } else if (method.equals(HttpPatch.METHOD_NAME)) {
-            apacheRequest = new HttpPatch(uri);
-        } else {
-            throw new IllegalArgumentException("no support for request method=" + method);
-        }
-            
-        /*
-        // headers support
-        String contentType = null;
-        FluentCaseInsensitiveStringsMap headers = request.getHeaders();
-        if (null != headers) {
-            for (Entry<String, List<String>> entry : headers.entrySet()) {
-                String name = entry.getKey();
-                List<String> valueList = entry.getValue();
-                if (null != name && null != valueList && valueList.size() > 0) {
-                    for (String value : valueList) {
-                        if (null == contentType && name.equals(AbstractHttpRequest.CONTENT_TYPE)) {
-                            contentType = value;
-                        }
-                        apacheRequest.addHeader(name, value);
-                    }
-                }
-            }
-        }
-        */
-        
-        return apacheRequest;
-    }
-    
-    private void addApacheRequestEntity(HttpRequestBase apacheRequest, 
-            String method,
-            String requestBodyJson,
-            Map<String, List<String>> formParams) {
-        HttpEntityEnclosingRequestBase apacheRequestSupportsEntity = 
-                apacheRequest instanceof HttpEntityEnclosingRequestBase 
-                ? (HttpEntityEnclosingRequestBase) apacheRequest 
-                        : null;
+		public Builder setRequestTimeoutInMs(int requestTimeoutInMs) {
+			this.apacheConfigBuilder.setSocketTimeout(requestTimeoutInMs);
+			return this;
+		}
 
-        // body support
-        if (null != formParams && formParams.size() > 0) {
-            if (null == apacheRequestSupportsEntity) {
-                throw new IllegalArgumentException("no formParams permitted for method "+method);
-            }
-            // form parameters support
-            // application/x-www-form-urlencoded only
-            apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_FORM_URLENCODED);
-            List<NameValuePair> parameters = new ArrayList<NameValuePair>();
-            for (Entry<String, List<String>> entry : formParams.entrySet()) {
-                String key = entry.getKey();
-                List<String> valueList = entry.getValue();
-                if (null != key && null != valueList && valueList.size() > 0) {
-                    String value = valueList.get(0);
-                    if (null != value) {
-                        NameValuePair nameValuePair = new BasicNameValuePair(key, value);
-                        parameters.add(nameValuePair);
-                    }
-                }
-            }
-            HttpEntity entity = new UrlEncodedFormEntity(parameters, HttpConstants.ENCODING_CHARSET);
-            apacheRequestSupportsEntity.setEntity(entity);
-        } else if (null != requestBodyJson) {
-            if (null == apacheRequestSupportsEntity) {
-                throw new IllegalArgumentException("no JSON request body permitted for method "+method);
-            }
-            // JSON body support
-            apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JSON);
-            byte[] bodyBytes = requestBodyJson.getBytes(HttpConstants.ENCODING_CHARSET);
-            if (null != bodyBytes) {
-                BasicHttpEntity entity = new BasicHttpEntity();
-                entity.setContent(new ByteArrayInputStream(bodyBytes));
-                entity.setContentLength(bodyBytes.length);
-                apacheRequestSupportsEntity.setEntity(entity);
-            }
-        }
+		public Builder setConnectionTimeoutInMs(int connectionTimeoutInMs) {
+			this.apacheConfigBuilder.setConnectTimeout(connectionTimeoutInMs)
+					.setConnectionRequestTimeout(connectionTimeoutInMs);
+			return this;
+		}
 
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
-            String requestBodyJson) {
-        HttpRequestBase apacheRequest = 
-                /*String method, String url, 
-            String requestBodyJson, Map<String, List<String>> formParams*/
-                getRequestNoAuth(method, url, requestBodyJson, null);
-        
-        ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
-        
-        // OAuth1
-        // NOTE: because this example uses application/json, not forms, our request bodies are 
-        // never part of the OAuth1 Authorization header.
-        Map<String, List<String>> formParams = null;
-        httpRequestAuthorizer.authorize(request, method, url, formParams);
+		/**
+		 * Build using builders, builders, and more builders.
+		 * 
+		 * @return the built HttpProvider implementation for Apache httpclient.
+		 */
+		public HttpProvider build() {
 
-        addApacheRequestEntity(apacheRequest, method, requestBodyJson, null);
-        
-        return request;
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
-            Map<String, List<String>> formParams) {
-        HttpRequestBase apacheRequest = 
-                /*String method, String url, 
-            String requestBodyJson, Map<String, List<String>> formParams*/
-                getRequestNoAuth(method, url, null, formParams);
-        
-        ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
-        
-        // OAuth1
-        // with application/x-www-form-urlencoded bodies, 
-        // the request body is supposed to impact the signature.
-        httpRequestAuthorizer.authorize(request, method, url, formParams);
+			CloseableHttpClient client = this.httpClient != null ? this.httpClient :
+			// uses PoolingHttpClientConnectionManager by default
+					HttpClientBuilder.create().setDefaultRequestConfig(apacheConfigBuilder.build()).build();
 
-        addApacheRequestEntity(apacheRequest, method, null, formParams);
-        
-        return request;
-    }
+			return new ApacheHttpClientProvider(client, this.doCloseHttpClient);
 
-    private final CloseableHttpClient httpClient;
-    private final boolean doCloseHttpClient;
+		}
+	}
 
-    public ApacheHttpClientProvider(CloseableHttpClient httpClient, boolean doCloseHttpClient) {
-        this.httpClient = httpClient;
-        this.doCloseHttpClient = doCloseHttpClient;
-    }
-    
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void close() throws IOException {
-        if (doCloseHttpClient && null != httpClient) {
-            httpClient.close();
-        }
-    }
+	private static class ApacheHttpClientRequest implements HttpRequest {
 
+		private final HttpRequestBase httpRequestBase;
 
-    @Override
-    public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
-        if (!(httpRequest instanceof ApacheHttpClientRequest)) {
-            throw new IllegalArgumentException("httpRequest is not of expected type; use "
-                    +getClass()+".getRequest(..) to get a request of the expected type");
-        }
-        HttpRequestBase httpRequestBase = ((ApacheHttpClientRequest) httpRequest).getHttpRequestBase();
-        
-        // we are stateless
-        HttpContext httpContext = null;
-        
-        try {
-            // blocking
-            org.apache.http.HttpResponse apacheHttpResponse = httpClient.execute(httpRequestBase, httpContext);
-            
-            return new ApacheHttpClientResponse(apacheHttpResponse);
-        } catch (ClientProtocolException e) {
-            throw new HttpException("trouble: " + e, e);
-        }
-    }
+		private ApacheHttpClientRequest(HttpRequestBase httpRequestBase) {
+			this.httpRequestBase = httpRequestBase;
+		}
+
+		private HttpRequestBase getHttpRequestBase() {
+			return httpRequestBase;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public void addAuthorizationHeader(String value) {
+			httpRequestBase.addHeader(HttpConstants.AUTHORIZATION_HEADER, value);
+		}
+	}
+
+	private static class ApacheHttpClientResponse implements HttpResponse {
+
+		private final org.apache.http.HttpResponse apacheHttpResponse;
+
+		private ApacheHttpClientResponse(org.apache.http.HttpResponse apacheHttpResponse) {
+			this.apacheHttpResponse = apacheHttpResponse;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public int getStatusCode() {
+			return apacheHttpResponse.getStatusLine().getStatusCode();
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public InputStream getResponseBody() throws IOException {
+			HttpEntity httpEntity = apacheHttpResponse.getEntity();
+			if (null != httpEntity) {
+				return httpEntity.getContent();
+			}
+			return null;
+		}
+
+		/**
+		 * {@inheritDoc}
+		 */
+		@Override
+		public long getContentLength() {
+			HttpEntity httpEntity = apacheHttpResponse.getEntity();
+			if (null != httpEntity) {
+				return httpEntity.getContentLength();
+			}
+			return 0L;
+		}
+
+	}
+
+	private HttpRequestBase getRequestNoAuth(String method, String url, String requestBodyJson,
+			Map<String, List<String>> formParams) {
+		URI uri;
+		try {
+			uri = new URI(url);
+		} catch (URISyntaxException e) {
+			throw new IllegalArgumentException("malformed URL: " + e, e);
+		}
+		HttpRequestBase apacheRequest = null;
+		if (method.equals(HttpGet.METHOD_NAME)) {
+			apacheRequest = new HttpGet(uri);
+		} else if (method.equals(HttpPost.METHOD_NAME)) {
+			apacheRequest = new HttpPost(uri);
+		} else if (method.equals(HttpPut.METHOD_NAME)) {
+			apacheRequest = new HttpPut(uri);
+		} else if (method.equals(HttpDelete.METHOD_NAME)) {
+			apacheRequest = new HttpDelete(uri);
+		} else if (method.equals(HttpHead.METHOD_NAME)) {
+			apacheRequest = new HttpHead(uri);
+		} else if (method.equals(HttpOptions.METHOD_NAME)) {
+			apacheRequest = new HttpOptions(uri);
+		} else if (method.equals(HttpTrace.METHOD_NAME)) {
+			apacheRequest = new HttpTrace(uri);
+		} else if (method.equals(HttpPatch.METHOD_NAME)) {
+			apacheRequest = new HttpPatch(uri);
+		} else {
+			throw new IllegalArgumentException("no support for request method=" + method);
+		}
+
+		/*
+		 * // headers support String contentType = null; FluentCaseInsensitiveStringsMap
+		 * headers = request.getHeaders(); if (null != headers) { for (Entry<String,
+		 * List<String>> entry : headers.entrySet()) { String name = entry.getKey();
+		 * List<String> valueList = entry.getValue(); if (null != name && null !=
+		 * valueList && valueList.size() > 0) { for (String value : valueList) { if
+		 * (null == contentType && name.equals(AbstractHttpRequest.CONTENT_TYPE)) {
+		 * contentType = value; } apacheRequest.addHeader(name, value); } } } }
+		 */
+
+		return apacheRequest;
+	}
+
+	private void addApacheRequestEntity(HttpRequestBase apacheRequest, String method, String requestBodyJson,
+			Map<String, List<String>> formParams) {
+		HttpEntityEnclosingRequestBase apacheRequestSupportsEntity = apacheRequest instanceof HttpEntityEnclosingRequestBase
+				? (HttpEntityEnclosingRequestBase) apacheRequest
+				: null;
+
+		// body support
+		if (null != formParams && formParams.size() > 0) {
+			if (null == apacheRequestSupportsEntity) {
+				throw new IllegalArgumentException("no formParams permitted for method " + method);
+			}
+			// form parameters support
+			// application/x-www-form-urlencoded only
+			apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE,
+					HttpConstants.CONTENT_TYPE_FORM_URLENCODED);
+			List<NameValuePair> parameters = new ArrayList<NameValuePair>();
+			for (Entry<String, List<String>> entry : formParams.entrySet()) {
+				String key = entry.getKey();
+				List<String> valueList = entry.getValue();
+				if (null != key && null != valueList && valueList.size() > 0) {
+					String value = valueList.get(0);
+					if (null != value) {
+						NameValuePair nameValuePair = new BasicNameValuePair(key, value);
+						parameters.add(nameValuePair);
+					}
+				}
+			}
+			HttpEntity entity = new UrlEncodedFormEntity(parameters, HttpConstants.ENCODING_CHARSET);
+			apacheRequestSupportsEntity.setEntity(entity);
+		} else if (null != requestBodyJson) {
+			if (null == apacheRequestSupportsEntity) {
+				throw new IllegalArgumentException("no JSON request body permitted for method " + method);
+			}
+			// JSON body support
+			apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JSON);
+			byte[] bodyBytes = requestBodyJson.getBytes(HttpConstants.ENCODING_CHARSET);
+			if (null != bodyBytes) {
+				BasicHttpEntity entity = new BasicHttpEntity();
+				entity.setContent(new ByteArrayInputStream(bodyBytes));
+				entity.setContentLength(bodyBytes.length);
+				apacheRequestSupportsEntity.setEntity(entity);
+			}
+		}
+
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
+			String requestBodyJson) {
+		HttpRequestBase apacheRequest =
+				/*
+				 * String method, String url, String requestBodyJson, Map<String, List<String>>
+				 * formParams
+				 */
+				getRequestNoAuth(method, url, requestBodyJson, null);
+
+		ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
+
+		// OAuth1
+		// NOTE: because this example uses application/json, not forms, our request
+		// bodies are
+		// never part of the OAuth1 Authorization header.
+		Map<String, List<String>> formParams = null;
+		httpRequestAuthorizer.authorize(request, method, url, formParams);
+
+		addApacheRequestEntity(apacheRequest, method, requestBodyJson, null);
+
+		return request;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
+			Map<String, List<String>> formParams) {
+		HttpRequestBase apacheRequest =
+				/*
+				 * String method, String url, String requestBodyJson, Map<String, List<String>>
+				 * formParams
+				 */
+				getRequestNoAuth(method, url, null, formParams);
+
+		ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
+
+		// OAuth1
+		// with application/x-www-form-urlencoded bodies,
+		// the request body is supposed to impact the signature.
+		httpRequestAuthorizer.authorize(request, method, url, formParams);
+
+		addApacheRequestEntity(apacheRequest, method, null, formParams);
+
+		return request;
+	}
+
+	private final CloseableHttpClient httpClient;
+	private final boolean doCloseHttpClient;
+
+	private ApacheHttpClientProvider(CloseableHttpClient httpClient, boolean doCloseHttpClient) {
+		this.httpClient = httpClient;
+		this.doCloseHttpClient = doCloseHttpClient;
+	}
+
+	/**
+	 * {@inheritDoc}
+	 */
+	@Override
+	public void close() throws IOException {
+		if (doCloseHttpClient && null != httpClient) {
+			httpClient.close();
+		}
+	}
+
+	@Override
+	public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
+		if (!(httpRequest instanceof ApacheHttpClientRequest)) {
+			throw new IllegalArgumentException("httpRequest is not of expected type; use " + getClass()
+					+ ".getRequest(..) to get a request of the expected type");
+		}
+		HttpRequestBase httpRequestBase = ((ApacheHttpClientRequest) httpRequest).getHttpRequestBase();
+
+		// we are stateless
+		HttpContext httpContext = null;
+
+		try {
+			// blocking
+			org.apache.http.HttpResponse apacheHttpResponse = httpClient.execute(httpRequestBase, httpContext);
+
+			return new ApacheHttpClientResponse(apacheHttpResponse);
+		} catch (ClientProtocolException e) {
+			throw new HttpException("trouble: " + e, e);
+		}
+	}
 
 }

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -62,9 +62,9 @@ import com.here.account.http.HttpProvider;
  * 
  * <pre>
  * {
- * 	&#64;code
- * 	HttpProvider httpProvider = ApacheHttpClientProvider.builder().build();
- * 	// use httpProvider such as with HereAccessTokenProviders...
+ *     @code
+ *     HttpProvider httpProvider = ApacheHttpClientProvider.builder().build();
+ *     // use httpProvider such as with HereAccessTokenProviders...
  * }
  * </pre>
  * 
@@ -73,298 +73,298 @@ import com.here.account.http.HttpProvider;
  */
 public class ApacheHttpClientProvider implements HttpProvider {
 
-	public static Builder builder() {
-		return new Builder();
-	}
+    public static Builder builder() {
+        return new Builder();
+    }
 
-	public static class Builder {
-		private RequestConfig.Builder apacheConfigBuilder;
-		private CloseableHttpClient httpClient;
-		private boolean doCloseHttpClient = true;
+    public static class Builder {
+        private RequestConfig.Builder apacheConfigBuilder;
+        private CloseableHttpClient httpClient;
+        private boolean doCloseHttpClient = true;
 
-		private Builder() {
-			apacheConfigBuilder = RequestConfig.custom();
-			setConnectionTimeoutInMs(HttpConstants.DEFAULT_CONNECTION_TIMEOUT_IN_MS);
-			setRequestTimeoutInMs(HttpConstants.DEFAULT_REQUEST_TIMEOUT_IN_MS);
-		}
+        private Builder() {
+            apacheConfigBuilder = RequestConfig.custom();
+            setConnectionTimeoutInMs(HttpConstants.DEFAULT_CONNECTION_TIMEOUT_IN_MS);
+            setRequestTimeoutInMs(HttpConstants.DEFAULT_REQUEST_TIMEOUT_IN_MS);
+        }
 
-		public Builder setHttpClient(final CloseableHttpClient httpClient) {
-			this.httpClient = httpClient;
-			return this;
-		}
+        public Builder setHttpClient(final CloseableHttpClient httpClient) {
+            this.httpClient = httpClient;
+            return this;
+        }
 
-		public Builder setDoCloseHttpClient(final boolean doCloseHttpClient) {
-			this.doCloseHttpClient = doCloseHttpClient;
-			return this;
-		}
+        public Builder setDoCloseHttpClient(final boolean doCloseHttpClient) {
+            this.doCloseHttpClient = doCloseHttpClient;
+            return this;
+        }
 
-		public Builder setRequestTimeoutInMs(int requestTimeoutInMs) {
-			this.apacheConfigBuilder.setSocketTimeout(requestTimeoutInMs);
-			return this;
-		}
+        public Builder setRequestTimeoutInMs(int requestTimeoutInMs) {
+            this.apacheConfigBuilder.setSocketTimeout(requestTimeoutInMs);
+            return this;
+        }
 
-		public Builder setConnectionTimeoutInMs(int connectionTimeoutInMs) {
-			this.apacheConfigBuilder.setConnectTimeout(connectionTimeoutInMs)
-					.setConnectionRequestTimeout(connectionTimeoutInMs);
-			return this;
-		}
+        public Builder setConnectionTimeoutInMs(int connectionTimeoutInMs) {
+            this.apacheConfigBuilder.setConnectTimeout(connectionTimeoutInMs)
+                    .setConnectionRequestTimeout(connectionTimeoutInMs);
+            return this;
+        }
 
-		/**
-		 * Build using builders, builders, and more builders.
-		 * 
-		 * @return the built HttpProvider implementation for Apache httpclient.
-		 */
-		public HttpProvider build() {
+        /**
+         * Build using builders, builders, and more builders.
+         * 
+         * @return the built HttpProvider implementation for Apache httpclient.
+         */
+        public HttpProvider build() {
 
-			CloseableHttpClient client = this.httpClient != null ? this.httpClient :
-			// uses PoolingHttpClientConnectionManager by default
-					HttpClientBuilder.create().setDefaultRequestConfig(apacheConfigBuilder.build()).build();
+            CloseableHttpClient client = this.httpClient != null ? this.httpClient :
+            // uses PoolingHttpClientConnectionManager by default
+                    HttpClientBuilder.create().setDefaultRequestConfig(apacheConfigBuilder.build()).build();
 
-			return new ApacheHttpClientProvider(client, this.doCloseHttpClient);
+            return new ApacheHttpClientProvider(client, this.doCloseHttpClient);
 
-		}
-	}
+        }
+    }
 
-	private static class ApacheHttpClientRequest implements HttpRequest {
+    private static class ApacheHttpClientRequest implements HttpRequest {
 
-		private final HttpRequestBase httpRequestBase;
+        private final HttpRequestBase httpRequestBase;
 
-		private ApacheHttpClientRequest(HttpRequestBase httpRequestBase) {
-			this.httpRequestBase = httpRequestBase;
-		}
+        private ApacheHttpClientRequest(HttpRequestBase httpRequestBase) {
+            this.httpRequestBase = httpRequestBase;
+        }
 
-		private HttpRequestBase getHttpRequestBase() {
-			return httpRequestBase;
-		}
+        private HttpRequestBase getHttpRequestBase() {
+            return httpRequestBase;
+        }
 
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public void addAuthorizationHeader(String value) {
-			httpRequestBase.addHeader(HttpConstants.AUTHORIZATION_HEADER, value);
-		}
-	}
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public void addAuthorizationHeader(String value) {
+            httpRequestBase.addHeader(HttpConstants.AUTHORIZATION_HEADER, value);
+        }
+    }
 
-	private static class ApacheHttpClientResponse implements HttpResponse {
+    private static class ApacheHttpClientResponse implements HttpResponse {
 
-		private final org.apache.http.HttpResponse apacheHttpResponse;
+        private final org.apache.http.HttpResponse apacheHttpResponse;
 
-		private ApacheHttpClientResponse(org.apache.http.HttpResponse apacheHttpResponse) {
-			this.apacheHttpResponse = apacheHttpResponse;
-		}
+        private ApacheHttpClientResponse(org.apache.http.HttpResponse apacheHttpResponse) {
+            this.apacheHttpResponse = apacheHttpResponse;
+        }
 
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public int getStatusCode() {
-			return apacheHttpResponse.getStatusLine().getStatusCode();
-		}
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public int getStatusCode() {
+            return apacheHttpResponse.getStatusLine().getStatusCode();
+        }
 
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public InputStream getResponseBody() throws IOException {
-			HttpEntity httpEntity = apacheHttpResponse.getEntity();
-			if (null != httpEntity) {
-				return httpEntity.getContent();
-			}
-			return null;
-		}
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public InputStream getResponseBody() throws IOException {
+            HttpEntity httpEntity = apacheHttpResponse.getEntity();
+            if (null != httpEntity) {
+                return httpEntity.getContent();
+            }
+            return null;
+        }
 
-		/**
-		 * {@inheritDoc}
-		 */
-		@Override
-		public long getContentLength() {
-			HttpEntity httpEntity = apacheHttpResponse.getEntity();
-			if (null != httpEntity) {
-				return httpEntity.getContentLength();
-			}
-			return 0L;
-		}
+        /**
+         * {@inheritDoc}
+         */
+        @Override
+        public long getContentLength() {
+            HttpEntity httpEntity = apacheHttpResponse.getEntity();
+            if (null != httpEntity) {
+                return httpEntity.getContentLength();
+            }
+            return 0L;
+        }
 
-	}
+    }
 
-	private HttpRequestBase getRequestNoAuth(String method, String url, String requestBodyJson,
-			Map<String, List<String>> formParams) {
-		URI uri;
-		try {
-			uri = new URI(url);
-		} catch (URISyntaxException e) {
-			throw new IllegalArgumentException("malformed URL: " + e, e);
-		}
-		HttpRequestBase apacheRequest = null;
-		if (method.equals(HttpGet.METHOD_NAME)) {
-			apacheRequest = new HttpGet(uri);
-		} else if (method.equals(HttpPost.METHOD_NAME)) {
-			apacheRequest = new HttpPost(uri);
-		} else if (method.equals(HttpPut.METHOD_NAME)) {
-			apacheRequest = new HttpPut(uri);
-		} else if (method.equals(HttpDelete.METHOD_NAME)) {
-			apacheRequest = new HttpDelete(uri);
-		} else if (method.equals(HttpHead.METHOD_NAME)) {
-			apacheRequest = new HttpHead(uri);
-		} else if (method.equals(HttpOptions.METHOD_NAME)) {
-			apacheRequest = new HttpOptions(uri);
-		} else if (method.equals(HttpTrace.METHOD_NAME)) {
-			apacheRequest = new HttpTrace(uri);
-		} else if (method.equals(HttpPatch.METHOD_NAME)) {
-			apacheRequest = new HttpPatch(uri);
-		} else {
-			throw new IllegalArgumentException("no support for request method=" + method);
-		}
+    private HttpRequestBase getRequestNoAuth(String method, String url, String requestBodyJson,
+            Map<String, List<String>> formParams) {
+        URI uri;
+        try {
+            uri = new URI(url);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException("malformed URL: " + e, e);
+        }
+        HttpRequestBase apacheRequest = null;
+        if (method.equals(HttpGet.METHOD_NAME)) {
+            apacheRequest = new HttpGet(uri);
+        } else if (method.equals(HttpPost.METHOD_NAME)) {
+            apacheRequest = new HttpPost(uri);
+        } else if (method.equals(HttpPut.METHOD_NAME)) {
+            apacheRequest = new HttpPut(uri);
+        } else if (method.equals(HttpDelete.METHOD_NAME)) {
+            apacheRequest = new HttpDelete(uri);
+        } else if (method.equals(HttpHead.METHOD_NAME)) {
+            apacheRequest = new HttpHead(uri);
+        } else if (method.equals(HttpOptions.METHOD_NAME)) {
+            apacheRequest = new HttpOptions(uri);
+        } else if (method.equals(HttpTrace.METHOD_NAME)) {
+            apacheRequest = new HttpTrace(uri);
+        } else if (method.equals(HttpPatch.METHOD_NAME)) {
+            apacheRequest = new HttpPatch(uri);
+        } else {
+            throw new IllegalArgumentException("no support for request method=" + method);
+        }
 
-		/*
-		 * // headers support String contentType = null; FluentCaseInsensitiveStringsMap
-		 * headers = request.getHeaders(); if (null != headers) { for (Entry<String,
-		 * List<String>> entry : headers.entrySet()) { String name = entry.getKey();
-		 * List<String> valueList = entry.getValue(); if (null != name && null !=
-		 * valueList && valueList.size() > 0) { for (String value : valueList) { if
-		 * (null == contentType && name.equals(AbstractHttpRequest.CONTENT_TYPE)) {
-		 * contentType = value; } apacheRequest.addHeader(name, value); } } } }
-		 */
+        /*
+         * // headers support String contentType = null; FluentCaseInsensitiveStringsMap
+         * headers = request.getHeaders(); if (null != headers) { for (Entry<String,
+         * List<String>> entry : headers.entrySet()) { String name = entry.getKey();
+         * List<String> valueList = entry.getValue(); if (null != name && null !=
+         * valueList && valueList.size() > 0) { for (String value : valueList) { if
+         * (null == contentType && name.equals(AbstractHttpRequest.CONTENT_TYPE)) {
+         * contentType = value; } apacheRequest.addHeader(name, value); } } } }
+         */
 
-		return apacheRequest;
-	}
+        return apacheRequest;
+    }
 
-	private void addApacheRequestEntity(HttpRequestBase apacheRequest, String method, String requestBodyJson,
-			Map<String, List<String>> formParams) {
-		HttpEntityEnclosingRequestBase apacheRequestSupportsEntity = apacheRequest instanceof HttpEntityEnclosingRequestBase
-				? (HttpEntityEnclosingRequestBase) apacheRequest
-				: null;
+    private void addApacheRequestEntity(HttpRequestBase apacheRequest, String method, String requestBodyJson,
+            Map<String, List<String>> formParams) {
+        HttpEntityEnclosingRequestBase apacheRequestSupportsEntity = apacheRequest instanceof HttpEntityEnclosingRequestBase
+                ? (HttpEntityEnclosingRequestBase) apacheRequest
+                : null;
 
-		// body support
-		if (null != formParams && formParams.size() > 0) {
-			if (null == apacheRequestSupportsEntity) {
-				throw new IllegalArgumentException("no formParams permitted for method " + method);
-			}
-			// form parameters support
-			// application/x-www-form-urlencoded only
-			apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE,
-					HttpConstants.CONTENT_TYPE_FORM_URLENCODED);
-			List<NameValuePair> parameters = new ArrayList<NameValuePair>();
-			for (Entry<String, List<String>> entry : formParams.entrySet()) {
-				String key = entry.getKey();
-				List<String> valueList = entry.getValue();
-				if (null != key && null != valueList && valueList.size() > 0) {
-					String value = valueList.get(0);
-					if (null != value) {
-						NameValuePair nameValuePair = new BasicNameValuePair(key, value);
-						parameters.add(nameValuePair);
-					}
-				}
-			}
-			HttpEntity entity = new UrlEncodedFormEntity(parameters, HttpConstants.ENCODING_CHARSET);
-			apacheRequestSupportsEntity.setEntity(entity);
-		} else if (null != requestBodyJson) {
-			if (null == apacheRequestSupportsEntity) {
-				throw new IllegalArgumentException("no JSON request body permitted for method " + method);
-			}
-			// JSON body support
-			apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JSON);
-			byte[] bodyBytes = requestBodyJson.getBytes(HttpConstants.ENCODING_CHARSET);
-			if (null != bodyBytes) {
-				BasicHttpEntity entity = new BasicHttpEntity();
-				entity.setContent(new ByteArrayInputStream(bodyBytes));
-				entity.setContentLength(bodyBytes.length);
-				apacheRequestSupportsEntity.setEntity(entity);
-			}
-		}
+        // body support
+        if (null != formParams && formParams.size() > 0) {
+            if (null == apacheRequestSupportsEntity) {
+                throw new IllegalArgumentException("no formParams permitted for method " + method);
+            }
+            // form parameters support
+            // application/x-www-form-urlencoded only
+            apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE,
+                    HttpConstants.CONTENT_TYPE_FORM_URLENCODED);
+            List<NameValuePair> parameters = new ArrayList<NameValuePair>();
+            for (Entry<String, List<String>> entry : formParams.entrySet()) {
+                String key = entry.getKey();
+                List<String> valueList = entry.getValue();
+                if (null != key && null != valueList && valueList.size() > 0) {
+                    String value = valueList.get(0);
+                    if (null != value) {
+                        NameValuePair nameValuePair = new BasicNameValuePair(key, value);
+                        parameters.add(nameValuePair);
+                    }
+                }
+            }
+            HttpEntity entity = new UrlEncodedFormEntity(parameters, HttpConstants.ENCODING_CHARSET);
+            apacheRequestSupportsEntity.setEntity(entity);
+        } else if (null != requestBodyJson) {
+            if (null == apacheRequestSupportsEntity) {
+                throw new IllegalArgumentException("no JSON request body permitted for method " + method);
+            }
+            // JSON body support
+            apacheRequestSupportsEntity.addHeader(HttpConstants.CONTENT_TYPE, HttpConstants.CONTENT_TYPE_JSON);
+            byte[] bodyBytes = requestBodyJson.getBytes(HttpConstants.ENCODING_CHARSET);
+            if (null != bodyBytes) {
+                BasicHttpEntity entity = new BasicHttpEntity();
+                entity.setContent(new ByteArrayInputStream(bodyBytes));
+                entity.setContentLength(bodyBytes.length);
+                apacheRequestSupportsEntity.setEntity(entity);
+            }
+        }
 
-	}
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
-			String requestBodyJson) {
-		HttpRequestBase apacheRequest =
-				/*
-				 * String method, String url, String requestBodyJson, Map<String, List<String>>
-				 * formParams
-				 */
-				getRequestNoAuth(method, url, requestBodyJson, null);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
+            String requestBodyJson) {
+        HttpRequestBase apacheRequest =
+                /*
+                 * String method, String url, String requestBodyJson, Map<String, List<String>>
+                 * formParams
+                 */
+                getRequestNoAuth(method, url, requestBodyJson, null);
 
-		ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
+        ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
 
-		// OAuth1
-		// NOTE: because this example uses application/json, not forms, our request
-		// bodies are
-		// never part of the OAuth1 Authorization header.
-		Map<String, List<String>> formParams = null;
-		httpRequestAuthorizer.authorize(request, method, url, formParams);
+        // OAuth1
+        // NOTE: because this example uses application/json, not forms, our request
+        // bodies are
+        // never part of the OAuth1 Authorization header.
+        Map<String, List<String>> formParams = null;
+        httpRequestAuthorizer.authorize(request, method, url, formParams);
 
-		addApacheRequestEntity(apacheRequest, method, requestBodyJson, null);
+        addApacheRequestEntity(apacheRequest, method, requestBodyJson, null);
 
-		return request;
-	}
+        return request;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
-			Map<String, List<String>> formParams) {
-		HttpRequestBase apacheRequest =
-				/*
-				 * String method, String url, String requestBodyJson, Map<String, List<String>>
-				 * formParams
-				 */
-				getRequestNoAuth(method, url, null, formParams);
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
+            Map<String, List<String>> formParams) {
+        HttpRequestBase apacheRequest =
+                /*
+                 * String method, String url, String requestBodyJson, Map<String, List<String>>
+                 * formParams
+                 */
+                getRequestNoAuth(method, url, null, formParams);
 
-		ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
+        ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
 
-		// OAuth1
-		// with application/x-www-form-urlencoded bodies,
-		// the request body is supposed to impact the signature.
-		httpRequestAuthorizer.authorize(request, method, url, formParams);
+        // OAuth1
+        // with application/x-www-form-urlencoded bodies,
+        // the request body is supposed to impact the signature.
+        httpRequestAuthorizer.authorize(request, method, url, formParams);
 
-		addApacheRequestEntity(apacheRequest, method, null, formParams);
+        addApacheRequestEntity(apacheRequest, method, null, formParams);
 
-		return request;
-	}
+        return request;
+    }
 
-	private final CloseableHttpClient httpClient;
-	private final boolean doCloseHttpClient;
+    private final CloseableHttpClient httpClient;
+    private final boolean doCloseHttpClient;
 
-	private ApacheHttpClientProvider(CloseableHttpClient httpClient, boolean doCloseHttpClient) {
-		this.httpClient = httpClient;
-		this.doCloseHttpClient = doCloseHttpClient;
-	}
+    private ApacheHttpClientProvider(CloseableHttpClient httpClient, boolean doCloseHttpClient) {
+        this.httpClient = httpClient;
+        this.doCloseHttpClient = doCloseHttpClient;
+    }
 
-	/**
-	 * {@inheritDoc}
-	 */
-	@Override
-	public void close() throws IOException {
-		if (doCloseHttpClient && null != httpClient) {
-			httpClient.close();
-		}
-	}
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+        if (doCloseHttpClient && null != httpClient) {
+            httpClient.close();
+        }
+    }
 
-	@Override
-	public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
-		if (!(httpRequest instanceof ApacheHttpClientRequest)) {
-			throw new IllegalArgumentException("httpRequest is not of expected type; use " + getClass()
-					+ ".getRequest(..) to get a request of the expected type");
-		}
-		HttpRequestBase httpRequestBase = ((ApacheHttpClientRequest) httpRequest).getHttpRequestBase();
+    @Override
+    public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
+        if (!(httpRequest instanceof ApacheHttpClientRequest)) {
+            throw new IllegalArgumentException("httpRequest is not of expected type; use " + getClass()
+                    + ".getRequest(..) to get a request of the expected type");
+        }
+        HttpRequestBase httpRequestBase = ((ApacheHttpClientRequest) httpRequest).getHttpRequestBase();
 
-		// we are stateless
-		HttpContext httpContext = null;
+        // we are stateless
+        HttpContext httpContext = null;
 
-		try {
-			// blocking
-			org.apache.http.HttpResponse apacheHttpResponse = httpClient.execute(httpRequestBase, httpContext);
+        try {
+            // blocking
+            org.apache.http.HttpResponse apacheHttpResponse = httpClient.execute(httpRequestBase, httpContext);
 
-			return new ApacheHttpClientResponse(apacheHttpResponse);
-		} catch (ClientProtocolException e) {
-			throw new HttpException("trouble: " + e, e);
-		}
-	}
+            return new ApacheHttpClientResponse(apacheHttpResponse);
+        } catch (ClientProtocolException e) {
+            throw new HttpException("trouble: " + e, e);
+        }
+    }
 
 }

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -185,7 +185,8 @@ public class ApacheHttpClientProvider implements HttpProvider {
 
     }
 
-    private HttpRequestBase getRequestNoAuth(String method, String url) {
+    private HttpRequestBase getRequestNoAuth(String method, String url, 
+            String requestBodyJson, Map<String, List<String>> formParams) {
         URI uri;
         try {
             uri = new URI(url);
@@ -291,8 +292,9 @@ public class ApacheHttpClientProvider implements HttpProvider {
     public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
             String requestBodyJson) {
         HttpRequestBase apacheRequest = 
-                /*String method, String url*/
-                getRequestNoAuth(method, url);
+                /*String method, String url, 
+            String requestBodyJson, Map<String, List<String>> formParams*/
+                getRequestNoAuth(method, url, requestBodyJson, null);
         
         ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
         
@@ -314,8 +316,9 @@ public class ApacheHttpClientProvider implements HttpProvider {
     public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
             Map<String, List<String>> formParams) {
         HttpRequestBase apacheRequest = 
-                /*String method, String url*/
-                getRequestNoAuth(method, url);
+                /*String method, String url, 
+            String requestBodyJson, Map<String, List<String>> formParams*/
+                getRequestNoAuth(method, url, null, formParams);
         
         ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
         

--- a/here-oauth-client/src/test/java/com/here/account/http/apache/ApacheHttpClientProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/http/apache/ApacheHttpClientProviderTest.java
@@ -213,38 +213,38 @@ public class ApacheHttpClientProviderTest {
     
     @Test
     public void test_assignHttpClientDirectly() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-    	CloseableHttpClient mock = mock(CloseableHttpClient.class);
-    	ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder().setHttpClient(mock).build();
-    	CloseableHttpClient fromProvider = extractHttpClient(provider);
-    	assertTrue("client must be SAME object",mock==fromProvider);
+        CloseableHttpClient mock = mock(CloseableHttpClient.class);
+        ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder().setHttpClient(mock).build();
+        CloseableHttpClient fromProvider = extractHttpClient(provider);
+        assertTrue("client must be SAME object",mock==fromProvider);
     }
     
     @Test
     public void test_setDoCloseToFalse() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException {
-    	CloseableHttpClient mock = mock(CloseableHttpClient.class);
-    	ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder()
-    			.setHttpClient(mock)
-    			.setDoCloseHttpClient(false).build();
+        CloseableHttpClient mock = mock(CloseableHttpClient.class);
+        ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder()
+                .setHttpClient(mock)
+                .setDoCloseHttpClient(false).build();
 
-    	provider.close();
-    	verify(mock,times(0)).close();
+        provider.close();
+        verify(mock,times(0)).close();
     }
     
     @Test
     public void test_setDoCloseToTrue() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException {
-    	CloseableHttpClient mock = mock(CloseableHttpClient.class);
-    	ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder()
-    			.setHttpClient(mock).build();
-    	
-    	provider.close();
-    	verify(mock,times(1)).close();
+        CloseableHttpClient mock = mock(CloseableHttpClient.class);
+        ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder()
+                .setHttpClient(mock).build();
+        
+        provider.close();
+        verify(mock,times(1)).close();
     }
     
     protected static CloseableHttpClient extractHttpClient(ApacheHttpClientProvider provider)  throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
-    	Field httpClientField = ApacheHttpClientProvider.class.getDeclaredField("httpClient");
-    	assertTrue("field was null", null != httpClientField);
-    	httpClientField.setAccessible(true);
-    	Object o = httpClientField.get(provider);
+        Field httpClientField = ApacheHttpClientProvider.class.getDeclaredField("httpClient");
+        assertTrue("field was null", null != httpClientField);
+        httpClientField.setAccessible(true);
+        Object o = httpClientField.get(provider);
         assertTrue("o was null", null != o);
         assertTrue("o wasn't an HttpRequestBase", CloseableHttpClient.class.isAssignableFrom(o.getClass()));
 

--- a/here-oauth-client/src/test/java/com/here/account/http/apache/ApacheHttpClientProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/http/apache/ApacheHttpClientProviderTest.java
@@ -20,6 +20,8 @@ import static org.junit.Assert.fail;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -38,6 +40,7 @@ import org.apache.http.client.methods.HttpPost;
 import org.apache.http.client.methods.HttpPut;
 import org.apache.http.client.methods.HttpRequestBase;
 import org.apache.http.client.methods.HttpTrace;
+import org.apache.http.impl.client.CloseableHttpClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
@@ -206,6 +209,47 @@ public class ApacheHttpClientProviderTest {
             String expectedContains = "no support for request method=BROKENMETHOD";
             assertTrue("expected contains "+expectedContains+", actual "+message, message.contains(expectedContains));
         }
+    }
+    
+    @Test
+    public void test_assignHttpClientDirectly() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+    	CloseableHttpClient mock = mock(CloseableHttpClient.class);
+    	ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder().setHttpClient(mock).build();
+    	CloseableHttpClient fromProvider = extractHttpClient(provider);
+    	assertTrue("client must be SAME object",mock==fromProvider);
+    }
+    
+    @Test
+    public void test_setDoCloseToFalse() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException {
+    	CloseableHttpClient mock = mock(CloseableHttpClient.class);
+    	ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder()
+    			.setHttpClient(mock)
+    			.setDoCloseHttpClient(false).build();
+
+    	provider.close();
+    	verify(mock,times(0)).close();
+    }
+    
+    @Test
+    public void test_setDoCloseToTrue() throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, IOException {
+    	CloseableHttpClient mock = mock(CloseableHttpClient.class);
+    	ApacheHttpClientProvider provider = (ApacheHttpClientProvider)ApacheHttpClientProvider.builder()
+    			.setHttpClient(mock).build();
+    	
+    	provider.close();
+    	verify(mock,times(1)).close();
+    }
+    
+    protected static CloseableHttpClient extractHttpClient(ApacheHttpClientProvider provider)  throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException {
+    	Field httpClientField = ApacheHttpClientProvider.class.getDeclaredField("httpClient");
+    	assertTrue("field was null", null != httpClientField);
+    	httpClientField.setAccessible(true);
+    	Object o = httpClientField.get(provider);
+        assertTrue("o was null", null != o);
+        assertTrue("o wasn't an HttpRequestBase", CloseableHttpClient.class.isAssignableFrom(o.getClass()));
+
+        return (CloseableHttpClient) o;
+        
     }
     
     protected void verifyApacheType(String method, Class<?> clazz) throws NoSuchFieldException, SecurityException, IllegalArgumentException, IllegalAccessException, ClassNotFoundException {


### PR DESCRIPTION
Set constructor of ApacheHttpClientProvider to PUBLIC. This allows for creation of ApacheHttpClientProviders which can reuse existing HttpClient-instances. Moreover this allows the user full control over HttpClient configuration (e.g. inclusion of PROXY settings)