### PR TITLE
credentials: Add HereAccessTokenProvider and Builder to use defaults …

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,11 @@ HERE Access Token.
 
 You can optionally add the `-v` option to print a full valid Id Token to stdout.
 
+HereAccessTokenProviderTutorial:
+
+In order to run the HereAccessTokenProviderTutorial class, run the following in terminal
+      $ java -cp examples/here-oauth-client-example/target/here-oauth-client-example-*[!javadoc][!sources].jar com.here.account.oauth2.tutorial.HereAccessTokenProviderTutorial
+
 Developer Usage
 ===============
 
@@ -169,3 +174,5 @@ of two options:
 - get a one time use HERE Access Token via TokenEndpoint.requestToken(..) approach
 - get Id Token via TokenEndpoint.requestToken(..) approach by setting the
 scope field in the request.
+
+- get

--- a/examples/here-oauth-client-example/src/main/java/com/here/account/oauth2/tutorial/HereAccessTokenProviderTutorial.java
+++ b/examples/here-oauth-client-example/src/main/java/com/here/account/oauth2/tutorial/HereAccessTokenProviderTutorial.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2.tutorial;
+
+import com.here.account.oauth2.HereAccessTokenProvider;
+
+/**
+ * A simple tutorial demonstrating how to get a HERE Access Token.
+ *
+ * @author kmccrack
+ */
+public class HereAccessTokenProviderTutorial {
+
+    public static void main(String[] argv) {
+        HereAccessTokenProviderTutorial t = new HereAccessTokenProviderTutorial();
+        t.doGetAccessToken();
+    }
+
+    private HereAccessTokenProviderTutorial() {
+    }
+
+    /**
+     * A simple method that builds a HereAccessTokenProvider,
+     * gets one Access Token,
+     * and if successful outputs the first few characters of the valid token.
+     */
+    protected void doGetAccessToken() {
+        try (
+            HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder().build()
+        ) {
+            String accessToken = accessTokens.getAccessToken();
+            useAccessToken(accessToken);
+        } catch (Exception e) {
+            trouble(e);
+        }
+
+    }
+
+    protected void useAccessToken(String accessToken) {
+        System.out.println("got access token " + accessToken.substring(0, 5) + "...");
+    }
+
+    protected void trouble(Exception e) {
+        System.err.println("trouble " + e);
+        e.printStackTrace();
+        exit(1);
+    }
+
+    protected void exit(int status) {
+        System.exit(status);
+    }
+
+}

--- a/here-oauth-client/pom.xml
+++ b/here-oauth-client/pom.xml
@@ -81,6 +81,10 @@
     <dependencies>
         <!-- compile dependencies -->
         <dependency>
+            <groupId>org.ini4j</groupId>
+            <artifactId>ini4j</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
         </dependency>

--- a/here-oauth-client/src/main/java/com/here/account/auth/NoAuthorizer.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/NoAuthorizer.java
@@ -1,0 +1,45 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth;
+
+import java.util.List;
+import java.util.Map;
+
+import com.here.account.http.HttpProvider;
+import com.here.account.http.HttpProvider.HttpRequest;
+
+/**
+ * Use this class, for use cases where you want no Authorization header 
+ * on your requests to the service.
+ * 
+ * @author kmccrack
+ */
+public class NoAuthorizer implements HttpProvider.HttpRequestAuthorizer {
+
+    /**
+     * Does nothing, as no Authorization header is required when using 
+     * instances of this class.
+     * 
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public void authorize(HttpRequest httpRequest, String method, String url, Map<String, List<String>> formParams) {
+        // nothing to do
+        // no Authorization header
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth1ClientCredentialsProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth1ClientCredentialsProvider.java
@@ -23,6 +23,9 @@ import java.util.Objects;
 import java.util.Properties;
 
 import com.here.account.http.HttpProvider;
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.oauth2.AccessTokenRequest;
+import com.here.account.oauth2.ClientCredentialsGrantRequest;
 import com.here.account.oauth2.ClientCredentialsProvider;
 
 /**
@@ -54,11 +57,17 @@ public class OAuth1ClientCredentialsProvider implements ClientCredentialsProvide
         this.oauth1Signer = new OAuth1Signer(accessKeyId, accessKeySecret);
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getTokenEndpointUrl() {
         return tokenEndpointUrl;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public HttpProvider.HttpRequestAuthorizer getClientAuthorizer() {
         return oauth1Signer;
@@ -92,7 +101,7 @@ public class OAuth1ClientCredentialsProvider implements ClientCredentialsProvide
                   properties.getProperty(ACCESS_KEY_SECRET_PROPERTY));
         }
     }
-    
+
     /**
      * An {@link FromProperties} that pulls credential values from the specified File.
      */
@@ -110,26 +119,44 @@ public class OAuth1ClientCredentialsProvider implements ClientCredentialsProvide
             super(getPropertiesFromFile(file));
         }
         
-        /**
-         * Loads the File as an InputStream into a new Properties object, 
-         * and returns it.
-         * 
-         * @param file the File to use as input
-         * @return the Properties populated from the specified file's contents
-         * @throws IOException
-         */
-        private static Properties getPropertiesFromFile(File file) throws IOException {
-            InputStream inputStream = null;
-            try {
-                inputStream = new FileInputStream(file);
-                Properties properties = new Properties();
-                properties.load(inputStream);
-                return properties;
-            } finally {
-                if (null != inputStream) {
-                    inputStream.close();
-                }
+    }
+
+    /**
+     * Loads the File as an InputStream into a new Properties object,
+     * and returns it.
+     *
+     * @param file the File to use as input
+     * @return the Properties populated from the specified file's contents
+     * @throws IOException if there is trouble reading the properties from the file
+     */
+    public static Properties getPropertiesFromFile(File file) throws IOException {
+        InputStream inputStream = null;
+        try {
+            inputStream = new FileInputStream(file);
+            Properties properties = new Properties();
+            properties.load(inputStream);
+            return properties;
+        } finally {
+            if (null != inputStream) {
+                inputStream.close();
             }
         }
     }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AccessTokenRequest getNewAccessTokenRequest() {
+        return new ClientCredentialsGrantRequest();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return HttpMethods.POST;
+    }
+
 }

--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth2Authorizer.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth2Authorizer.java
@@ -17,6 +17,7 @@ package com.here.account.auth;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpProvider.HttpRequest;
@@ -39,6 +40,7 @@ public class OAuth2Authorizer implements HttpProvider.HttpRequestAuthorizer {
     private static final String BEARER_SPACE = "Bearer ";
     
     private final String bearerSpaceAccessToken;
+    private final Supplier<String> accessTokenSupplier;
     
     /**
      * Construct the Bearer authorizer with the specified <tt>accessToken</tt>.
@@ -50,6 +52,23 @@ public class OAuth2Authorizer implements HttpProvider.HttpRequestAuthorizer {
      */
     public OAuth2Authorizer(String accessToken) {
         this.bearerSpaceAccessToken = BEARER_SPACE + accessToken;
+        this.accessTokenSupplier = null;
+    }
+    
+    /**
+     * Construct the Bearer authorizer with the specified <tt>accessTokenSupplier</tt>.
+     * This allows the <tt>accessTokenSupplier</tt> to change the Access Token it uses 
+     * as needed, such as to avoid token expiration.
+     * Access Token is as defined in 
+     * <a href="https://tools.ietf.org/html/rfc6749#section-1.4">OAuth2.0 
+     * Section 1.4</a>.
+     *  
+     * @param accessTokenSupplier the Supplier for 
+     *      the OAuth2.0 Bearer Access Token values
+     */
+    public OAuth2Authorizer(Supplier<String> accessTokenSupplier) {
+        this.bearerSpaceAccessToken = null;
+        this.accessTokenSupplier = accessTokenSupplier;
     }
 
     /**
@@ -57,7 +76,11 @@ public class OAuth2Authorizer implements HttpProvider.HttpRequestAuthorizer {
      */
     @Override
     public void authorize(HttpRequest httpRequest, String method, String url, Map<String, List<String>> formParams) {
-        httpRequest.addAuthorizationHeader(bearerSpaceAccessToken);
+        if (null != bearerSpaceAccessToken) {
+            httpRequest.addAuthorizationHeader(bearerSpaceAccessToken);
+        } else {
+            httpRequest.addAuthorizationHeader(BEARER_SPACE + accessTokenSupplier.get());
+        }
     }
 
 }

--- a/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
@@ -50,9 +50,9 @@ public class SignatureCalculator {
      */
     public static final String ELLIPTIC_CURVE_ALGORITHM = "EC";
 
-    public SignatureCalculator(String clientAccessKeyId, String clientAccessKeySecret) {
-        this.consumerKey = clientAccessKeyId;
-        this.consumerSecret = clientAccessKeySecret;
+    public SignatureCalculator(String consumerKey, String consumerSecret) {
+        this.consumerKey = consumerKey;
+        this.consumerSecret = consumerSecret;
     }
 
     /**
@@ -139,7 +139,7 @@ public class SignatureCalculator {
      * @param formParams      the list of form parameters
      * @param queryParams     list of query parameters
      * @param signatureToVerify the signature bytes to be verified.
-     * @param verificationKey  the key used to verify the signature. This will be the consumer key for HMAC-SHAn signature
+     * @param verificationKey  the key used to verify the signature. This will be the shared secret key for HMAC-SHAn signature
      *                         method and is the public key for ES512 signature method.
      *
      * @return true if the signature was verified, false if not.
@@ -161,7 +161,7 @@ public class SignatureCalculator {
     /**
      * Verify the signature.
      *
-     * @param cipherText    the original text that was signed.
+     * @param signedText    the original text that was signed.
      * @param signatureMethod signature method to be used - supported are HMAC-SHA1, HMAC-SHA256, ES512
      * @param signatureToVerify the signature bytes to be verified.
      * @param verificationKey  the key used to verify the signature. This will be the consumer key for HMAC-SHAn signature
@@ -169,11 +169,11 @@ public class SignatureCalculator {
      *
      * @return true if the signature was verified, false if not.
      */
-    protected static boolean verifySignature(String cipherText, SignatureMethod signatureMethod, String signatureToVerify, String verificationKey) {
+    protected static boolean verifySignature(String signedText, SignatureMethod signatureMethod, String signatureToVerify, String verificationKey) {
         if (signatureMethod.equals(SignatureMethod.ES512))
-            return verifyECDSASignature(cipherText, signatureToVerify, verificationKey, signatureMethod);
+            return verifyECDSASignature(signedText, signatureToVerify, verificationKey, signatureMethod);
         else
-            return (generateSignature(cipherText, verificationKey, signatureMethod).equals(signatureToVerify));
+            return (generateSignature(signedText, verificationKey, signatureMethod).equals(signatureToVerify));
     }
 
 

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/ClientAuthorizationProviderChain.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/ClientAuthorizationProviderChain.java
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.logging.Logger;
+
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.AccessTokenRequest;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.oauth2.ClientCredentialsProvider;
+
+/**
+ * @author kmccrack
+ */
+public class ClientAuthorizationProviderChain implements ClientAuthorizationRequestProvider {
+
+    private static final Logger LOG = Logger.getLogger(ClientAuthorizationProviderChain.class.getName());
+    private ClientAuthorizationRequestProvider mostRecentProvider = null;
+    private List<ClientAuthorizationRequestProvider> clientAuthorizationProviders;
+
+    public ClientAuthorizationProviderChain(ClientAuthorizationRequestProvider... clientAuthorizationProviders) {
+        this.clientAuthorizationProviders = new ArrayList<ClientAuthorizationRequestProvider>();
+        for (ClientAuthorizationRequestProvider clientAuthorizationProvider : clientAuthorizationProviders) {
+            this.clientAuthorizationProviders.add(clientAuthorizationProvider);
+        }
+    }
+
+    public ClientAuthorizationProviderChain(List<ClientCredentialsProvider> clientAuthorizationProviders) {
+        this.clientAuthorizationProviders = new ArrayList<ClientAuthorizationRequestProvider>(clientAuthorizationProviders);
+    }
+
+    public static ClientAuthorizationProviderChain DEFAULT_CLIENT_CREDENTIALS_PROVIDER_CHAIN = getDefaultClientCredentialsProviderChain();
+
+    private static ClientAuthorizationProviderChain getDefaultClientCredentialsProviderChain() {
+        ClientAuthorizationRequestProvider systemProvider = new FromSystemProperties();
+        ClientAuthorizationRequestProvider iniFileProvider = new FromHereCredentialsIniFile();
+        ClientAuthorizationRequestProvider propertiesFileProvider = new FromDefaultHereCredentialsPropertiesFile();
+        return new ClientAuthorizationProviderChain(
+                systemProvider,
+                iniFileProvider,
+                propertiesFileProvider
+                );
+    }
+
+    protected ClientAuthorizationRequestProvider getClientCredentialsProvider() {
+        if (mostRecentProvider != null) {
+            return mostRecentProvider;
+        }
+
+        for (ClientAuthorizationRequestProvider credentials : clientAuthorizationProviders) {
+            try {
+                if (null != credentials.getTokenEndpointUrl() && credentials.getTokenEndpointUrl() != ""
+                    && null != credentials.getClientAuthorizer()) {
+                    LOG.info("Loading credentials from " + credentials.toString());
+
+                    mostRecentProvider = credentials;
+                    return credentials;
+                }
+            } catch (Exception e) {
+                // Ignore any exceptions and move onto the next provider
+                LOG.warning("Unable to load credentials from " + credentials.toString() +
+                        ": " + e.getMessage());
+            }
+        }
+
+        throw new RequestProviderException("Unable to load credentials from chain");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTokenEndpointUrl() {
+        return getClientCredentialsProvider().getTokenEndpointUrl();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequestAuthorizer getClientAuthorizer() {
+        return getClientCredentialsProvider().getClientAuthorizer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AccessTokenRequest getNewAccessTokenRequest() {
+        return getClientCredentialsProvider().getNewAccessTokenRequest();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return getClientCredentialsProvider().getHttpMethod();
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/ClientCredentialsGrantRequestProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/ClientCredentialsGrantRequestProvider.java
@@ -1,24 +1,32 @@
 /*
- * Copyright (c) 2016 HERE Europe B.V.
- * 
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.here.account.oauth2;
+package com.here.account.auth.provider;
 
-/**
- * A {@code ClientCredentialsProvider} identifies a token endpoint and provides
- * a mechanism to use credentials to authorize access token requests.
- */
-public interface ClientCredentialsProvider extends ClientAuthorizationRequestProvider {
+import com.here.account.oauth2.AccessTokenRequest;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.oauth2.ClientCredentialsGrantRequest;
+
+public abstract class ClientCredentialsGrantRequestProvider implements ClientAuthorizationRequestProvider {
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AccessTokenRequest getNewAccessTokenRequest() {
+        return new ClientCredentialsGrantRequest();
+    }
     
 }

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/DefaultHereConfigFiles.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/DefaultHereConfigFiles.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import java.io.File;
+
+/**
+ * @author kmccrack
+ */
+class DefaultHereConfigFiles {
+    private static final String USER_DOT_HOME = "user.home";
+    private static final String DOT_HERE_SUBDIR = ".here";
+
+    static File getDefaultHereConfigFile(String name) {
+        String userDotHome = System.getProperty(USER_DOT_HOME);
+        if (userDotHome != null && userDotHome.length() > 0) {
+            File dir = new File(userDotHome, DOT_HERE_SUBDIR);
+            File file = new File(dir, name);
+            return file;
+        }
+        return null;
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromDefaultHereCredentialsPropertiesFile.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromDefaultHereCredentialsPropertiesFile.java
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Properties;
+
+import com.here.account.auth.OAuth1ClientCredentialsProvider;
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.oauth2.ClientCredentialsProvider;
+
+/**
+ * A {@link ClientCredentialsProvider} that pulls credential values from the
+ * default "~/.here/credentials.properties" file.
+ */
+public class FromDefaultHereCredentialsPropertiesFile extends ClientCredentialsGrantRequestProvider 
+implements ClientAuthorizationRequestProvider {
+
+    private static final String CREDENTIALS_DOT_PROPERTIES_FILENAME = "credentials.properties";
+
+    public FromDefaultHereCredentialsPropertiesFile() {
+    }
+
+    protected ClientCredentialsProvider getClientCredentialsProvider() {
+        File file = getDefaultHereCredentialsFile();
+        try {
+            Properties properties = OAuth1ClientCredentialsProvider.getPropertiesFromFile(file);
+            return FromSystemProperties.getClientCredentialsProviderWithDefaultTokenEndpointUrl(properties);
+        } catch (IOException e) {
+            throw new RequestProviderException("trouble FromFile " + e, e);
+        }
+    }
+
+    static File getDefaultHereCredentialsFile() {
+        return DefaultHereConfigFiles.getDefaultHereConfigFile(CREDENTIALS_DOT_PROPERTIES_FILENAME);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTokenEndpointUrl() {
+        return getClientCredentialsProvider().getTokenEndpointUrl();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequestAuthorizer getClientAuthorizer() {
+        return getClientCredentialsProvider().getClientAuthorizer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return HttpMethods.POST;
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromHereCredentialsIniFile.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromHereCredentialsIniFile.java
@@ -1,0 +1,96 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
+
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+
+/**
+ * @author kmccrack
+ */
+public class FromHereCredentialsIniFile extends ClientCredentialsGrantRequestProvider
+implements ClientAuthorizationRequestProvider {
+
+    private static final String CREDENTIALS_DOT_INI_FILENAME = "credentials.ini";
+
+    private final File file;
+    private final String sectionName;
+    
+    public FromHereCredentialsIniFile() {
+        this(getDefaultHereCredentialsIniFile(), FromHereCredentialsIniStream.DEFAULT_INI_SECTION_NAME);
+    }
+
+    public FromHereCredentialsIniFile(File file, String sectionName) {
+        Objects.requireNonNull(file, "file is required");
+
+        this.file = file;
+        this.sectionName = sectionName;
+    }
+    
+    /**
+     * The delegate allows for reloading the file each time it is used, 
+     * in case it has changed.
+     * 
+     * @return the ClientAuthorizationRequestProvider
+     */
+    protected ClientAuthorizationRequestProvider getDelegate() {
+        try (InputStream inputStream = new FileInputStream(file)) {
+            return new FromHereCredentialsIniStream(inputStream, sectionName);
+        } catch (IOException e) {
+            throw new RequestProviderException("trouble FromFile " + e, e);
+        }
+    }
+    
+    protected File getFile() {
+        return file;
+    }
+
+    protected static File getDefaultHereCredentialsIniFile() {
+        return DefaultHereConfigFiles.getDefaultHereConfigFile(CREDENTIALS_DOT_INI_FILENAME);
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTokenEndpointUrl() {
+        return getDelegate().getTokenEndpointUrl();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequestAuthorizer getClientAuthorizer() {
+        return getDelegate().getClientAuthorizer();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return HttpMethods.POST;
+    }
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromHereCredentialsIniStream.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromHereCredentialsIniStream.java
@@ -1,0 +1,89 @@
+package com.here.account.auth.provider;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.Objects;
+import java.util.Properties;
+
+import org.ini4j.Ini;
+
+import com.here.account.auth.OAuth1ClientCredentialsProvider;
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.util.OAuthConstants;
+
+public class FromHereCredentialsIniStream extends ClientCredentialsGrantRequestProvider
+implements ClientAuthorizationRequestProvider {
+
+    private final ClientAuthorizationRequestProvider delegate;
+    
+    public FromHereCredentialsIniStream(InputStream inputStream) {
+        this(inputStream, DEFAULT_INI_SECTION_NAME);
+    }
+    
+    public FromHereCredentialsIniStream(InputStream inputStream, String sectionName) {
+        Objects.requireNonNull(inputStream, "inputStream is required");
+        
+        // the delegate is fixed, because you cannot rewind an inputStream
+        this.delegate = getClientCredentialsProvider(inputStream, sectionName);
+    }
+    
+    protected ClientAuthorizationRequestProvider getDelegate() {
+        return delegate;
+    }
+        
+    protected static ClientAuthorizationRequestProvider getClientCredentialsProvider(InputStream inputStream, String sectionName) {
+        try {
+            Properties properties = getPropertiesFromIni(inputStream, sectionName);
+            return FromSystemProperties.getClientCredentialsProviderWithDefaultTokenEndpointUrl(properties);
+        } catch (IOException e) {
+            throw new RequestProviderException("trouble FromFile " + e, e);
+        }
+    }
+
+    static final String DEFAULT_INI_SECTION_NAME = "default";
+    
+    static Properties getPropertiesFromIni(InputStream inputStream, String sectionName) throws IOException {
+        Ini ini = new Ini();
+        try (Reader reader = new InputStreamReader(inputStream, OAuthConstants.UTF_8_CHARSET)) {
+            ini.load(reader);
+            Ini.Section section = ini.get(sectionName);
+            Properties properties = new Properties();
+            properties.put(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY,
+                    section.get(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY));
+            properties.put(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY,
+                    section.get(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY));
+            properties.put(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY,
+                    section.get(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY));
+            return properties;
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTokenEndpointUrl() {
+        return getDelegate().getTokenEndpointUrl();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequestAuthorizer getClientAuthorizer() {
+        return getDelegate().getClientAuthorizer();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return HttpMethods.POST;
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromSystemProperties.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromSystemProperties.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import java.util.Properties;
+
+import com.here.account.auth.OAuth1ClientCredentialsProvider;
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.oauth2.ClientCredentialsProvider;
+
+/**
+ * A {@link ClientCredentialsProvider} that pulls credential values from the System Properties.
+ */
+public class FromSystemProperties extends ClientCredentialsGrantRequestProvider
+implements ClientAuthorizationRequestProvider {
+    public FromSystemProperties() {
+    }
+
+    protected ClientCredentialsProvider getDelegate() {
+        Properties properties = System.getProperties();
+        return getClientCredentialsProviderWithDefaultTokenEndpointUrl(properties);
+    }
+
+    private static final String DEFAULT_TOKEN_ENDPOINT_URL = "https://account.api.here.com/oauth2/token";
+
+    static ClientCredentialsProvider getClientCredentialsProviderWithDefaultTokenEndpointUrl(Properties properties) {
+        return new OAuth1ClientCredentialsProvider(
+                properties.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, DEFAULT_TOKEN_ENDPOINT_URL),
+                properties.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY),
+                properties.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY)
+        );
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTokenEndpointUrl() {
+        return getDelegate().getTokenEndpointUrl();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequestAuthorizer getClientAuthorizer() {
+        return getDelegate().getClientAuthorizer();
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return HttpMethods.POST;
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/RequestProviderException.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/RequestProviderException.java
@@ -1,24 +1,27 @@
 /*
- * Copyright (c) 2016 HERE Europe B.V.
- * 
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.here.account.oauth2;
+package com.here.account.auth.provider;
 
-/**
- * A {@code ClientCredentialsProvider} identifies a token endpoint and provides
- * a mechanism to use credentials to authorize access token requests.
- */
-public interface ClientCredentialsProvider extends ClientAuthorizationRequestProvider {
+public class RequestProviderException extends RuntimeException {
+
+    public RequestProviderException(String msg) {
+        super(msg);
+    }
     
+    public RequestProviderException(String msg, Throwable cause) {
+        super(msg, cause);
+    }
 }

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/incubator/RunAsIdAuthorizationProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/incubator/RunAsIdAuthorizationProvider.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider.incubator;
+
+import java.util.List;
+import java.util.Map;
+
+import com.here.account.auth.NoAuthorizer;
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.AccessTokenRequest;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+
+/**
+ * An incubator class that may be removed in subsequent releases,
+ * or refactored into the parent package.
+ * 
+ * <p>
+ * Gets authorization Access Tokens from an identity access token file.
+ * 
+ * @deprecated subject to removal, or non-backwards-compatible changes
+ * @author kmccrack
+ */
+public class RunAsIdAuthorizationProvider implements ClientAuthorizationRequestProvider {
+
+    /**
+     * The HERE Access Token URL.
+     */
+    private static final String RUN_AS_ID_TOKEN_ENDPOINT_URL = 
+            "http://localhost:8001/token";
+    
+    private final String tokenEndpointUrl;
+    
+    public RunAsIdAuthorizationProvider() {
+        this(RUN_AS_ID_TOKEN_ENDPOINT_URL);
+    }
+
+    public RunAsIdAuthorizationProvider(String tokenEndpointUrl) {
+        this.tokenEndpointUrl = tokenEndpointUrl;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getTokenEndpointUrl() {
+        return tokenEndpointUrl;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpRequestAuthorizer getClientAuthorizer() {
+        return new NoAuthorizer();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public AccessTokenRequest getNewAccessTokenRequest() {
+        return new AccessTokenRequest(null) {
+            
+            /**
+             * HTTP GETs cannot have request bodies.
+             * 
+             * @return null, indicating no form params/request body
+             */
+            @Override
+            public Map<String, List<String>> toFormParams() {
+                return null;
+            }
+        };
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public HttpMethods getHttpMethod() {
+        return HttpMethods.GET;
+    }
+    
+}

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/package-info.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/package-info.java
@@ -13,12 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.here.account.oauth2;
 
 /**
- * A {@code ClientCredentialsProvider} identifies a token endpoint and provides
- * a mechanism to use credentials to authorize access token requests.
+ * Provider classes to pull credentials from different sources like system properties, ini and properties file
+ * and in an order of priority specified.
  */
-public interface ClientCredentialsProvider extends ClientAuthorizationRequestProvider {
-    
-}
+package com.here.account.auth.provider;

--- a/here-oauth-client/src/main/java/com/here/account/client/Client.java
+++ b/here-oauth-client/src/main/java/com/here/account/client/Client.java
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.client;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.function.BiFunction;
+
+import com.here.account.http.HttpException;
+import com.here.account.http.HttpProvider;
+import com.here.account.http.HttpProvider.HttpRequest;
+import com.here.account.oauth2.AccessTokenException;
+import com.here.account.oauth2.RequestExecutionException;
+import com.here.account.oauth2.ResponseParsingException;
+import com.here.account.util.Serializer;
+
+/**
+ * A Client that talks to a Resource Server, in OAuth2-speak.
+ * It is expected that a wrapper class invokes methods on an instance 
+ * of this class, so that simple Java create(), read(), update(), 
+ * and delete() methods can be written with POJOs.
+ * 
+ * Suitable for use with JSON-object response APIs.
+ * 
+ * @author kmccrack
+ */
+public class Client {
+
+    public static class Builder {
+        private HttpProvider httpProvider;
+        private Serializer serializer;
+        private HttpProvider.HttpRequestAuthorizer clientAuthorizer;
+
+        private Builder() {
+
+        }
+
+        public Builder withHttpProvider(HttpProvider httpProvider) {
+            this.httpProvider = httpProvider;
+            return this;
+        }
+
+        public Builder withSerializer(Serializer serializer) {
+            this.serializer = serializer;
+            return this;
+        }
+
+        public Builder withClientAuthorizer(HttpProvider.HttpRequestAuthorizer clientAuthorizer) {
+            this.clientAuthorizer = clientAuthorizer;
+            return this;
+        }
+
+        public Client build() {
+            return new Client(httpProvider, serializer, clientAuthorizer);
+        }
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    private final HttpProvider httpProvider;
+    private final Serializer serializer;
+    private final HttpProvider.HttpRequestAuthorizer clientAuthorizer;
+
+    private Client(HttpProvider httpProvider, Serializer serializer,
+                    HttpProvider.HttpRequestAuthorizer clientAuthorizer) {
+        this.httpProvider = httpProvider;
+        this.serializer = serializer;
+        this.clientAuthorizer = clientAuthorizer;
+    }
+
+    /**
+     * Sends the requested HTTP Message to the Server.
+     * This method is useful if you want to interact with your 
+     * Resource Server using serializable Java objects as inputs and outputs.
+     * It covers the case where your Resource Server API uses 
+     * Content-Type: application/json for request and response 
+     * documents.
+     *
+     * @param method the HTTP method
+     * @param url the HTTP request URL
+     * @param request the request object of type R, or null if no request object
+     * @param responseClass the response object class, for deserialization
+     * @param errorResponseClass the response error object class, for deserialization
+     * @param newExceptionFunction the function for getting a new RuntimeException based
+     *      on the statusCode and error response object
+     * @param <R> the Request parameterized type
+     * @param <T> the Response parameterized type
+     * @param <U> the Response Error parameterized type
+     * @return the Response of type T
+     * @throws AccessTokenException
+     * @throws RequestExecutionException
+     * @throws ResponseParsingException
+     */
+    public <R, T, U> T sendMessage(
+            String method,
+            String url,
+            R request,
+            Class<T> responseClass,
+            Class<U> errorResponseClass,
+            BiFunction<Integer, U, RuntimeException> newExceptionFunction)
+            throws AccessTokenException, RequestExecutionException, ResponseParsingException {
+
+        HttpProvider.HttpRequest httpRequest;
+        if (null == request) {
+            httpRequest = httpProvider.getRequest(
+                    clientAuthorizer, method, url, (String) null);
+        } else {
+            // HttpConstants.ContentTypes.JSON == requestContentType
+            String jsonBody = serializer.objectToJson(request);
+            httpRequest = httpProvider.getRequest(
+                        clientAuthorizer, method, url, jsonBody);
+        }
+
+        return sendMessage(httpRequest, responseClass,
+                errorResponseClass, newExceptionFunction);
+    }
+    
+    /**
+     * Sends the requested HTTP Message to the Server.
+     * This method is useful if you have already constructed your 
+     * HttpRequest, and your API supports 
+     * Content-Type: application/json response documents.
+     *
+     * @param httpRequest the HTTP Request
+     * @param responseClass the Response class
+     * @param <T> the Response parameterized type
+     * @param <U> the Response Error parameterized type
+     * @return the Response object, deserialized
+     */
+    public <T, U> T sendMessage(HttpRequest httpRequest, Class<T> responseClass,
+            Class<U> errorResponseClass,
+            BiFunction<Integer, U, RuntimeException> newExceptionFunction) 
+            throws AccessTokenException, RequestExecutionException, ResponseParsingException {
+        // blocking
+        HttpProvider.HttpResponse apacheResponse = null;
+        InputStream jsonInputStream = null;
+
+        try {
+            apacheResponse = httpProvider.execute(httpRequest);
+            jsonInputStream = apacheResponse.getResponseBody();
+        } catch (IOException | HttpException e) {
+            throw new RequestExecutionException(e);
+        }
+
+        int statusCode = apacheResponse.getStatusCode();
+        try {
+            if (200 == statusCode || 201 == statusCode || 204 == statusCode) {
+                try {
+                    return serializer.jsonToPojo(jsonInputStream,
+                            responseClass);
+                } catch (Exception e) {
+                    throw new ResponseParsingException(e);
+                }
+            } else {
+                U errorResponse;
+                try {
+                    // parse the error response
+                    errorResponse = serializer.jsonToPojo(jsonInputStream, errorResponseClass);
+                } catch (Exception e) {
+                    // if there is trouble parsing the error
+                    throw new ResponseParsingException(e);
+                }
+                throw newExceptionFunction.apply(statusCode, errorResponse);
+            }
+        } finally {
+            nullSafeCloseThrowingUnchecked(jsonInputStream);
+        }
+    }
+
+    /**
+     * A null-safe invocation of closeable.close(), such that if an IOException is 
+     * triggered, it is wrapped instead in an UncheckedIOException.
+     * 
+     * @param closeable the closeable to be closed
+     */
+    static void nullSafeCloseThrowingUnchecked(Closeable closeable) {
+        if (null != closeable) {
+            try {
+                closeable.close();
+            } catch (IOException ioe) {
+                throw new UncheckedIOException(ioe);
+            }
+        }
+
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/client/package-info.java
+++ b/here-oauth-client/src/main/java/com/here/account/client/package-info.java
@@ -13,12 +13,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package com.here.account.oauth2;
 
 /**
- * A {@code ClientCredentialsProvider} identifies a token endpoint and provides
- * a mechanism to use credentials to authorize access token requests.
+ * A general purpose client class that talks to a Resource Server, in OAuth2-speak.
  */
-public interface ClientCredentialsProvider extends ClientAuthorizationRequestProvider {
-    
-}
+package com.here.account.client;

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpConstants.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpConstants.java
@@ -39,4 +39,23 @@ public class HttpConstants {
     public static final int DEFAULT_REQUEST_TIMEOUT_IN_MS = 5000;
     public static final int DEFAULT_CONNECTION_TIMEOUT_IN_MS = 5000;
 
+    public static enum HttpMethods {
+        GET("GET"),
+        POST("POST");
+        
+        private final String method;
+        
+        private HttpMethods(String method) {
+            this.method = method;
+        }
+        
+        /**
+         * Returns the HTTP Method to be sent with the HTTP Request message.
+         * 
+         * @return the HTTP method
+         */
+        public String getMethod() {
+            return method;
+        }
+    }
 }

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -174,8 +174,7 @@ public class ApacheHttpClientProvider implements HttpProvider {
 
     }
 
-    private HttpRequestBase getRequestNoAuth(String method, String url, 
-            String requestBodyJson, Map<String, List<String>> formParams) {
+    private HttpRequestBase getRequestNoAuth(String method, String url) {
         URI uri;
         try {
             uri = new URI(url);
@@ -281,9 +280,8 @@ public class ApacheHttpClientProvider implements HttpProvider {
     public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
             String requestBodyJson) {
         HttpRequestBase apacheRequest = 
-                /*String method, String url, 
-            String requestBodyJson, Map<String, List<String>> formParams*/
-                getRequestNoAuth(method, url, requestBodyJson, null);
+                /*String method, String url*/
+                getRequestNoAuth(method, url);
         
         ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
         
@@ -305,9 +303,8 @@ public class ApacheHttpClientProvider implements HttpProvider {
     public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url,
             Map<String, List<String>> formParams) {
         HttpRequestBase apacheRequest = 
-                /*String method, String url, 
-            String requestBodyJson, Map<String, List<String>> formParams*/
-                getRequestNoAuth(method, url, null, formParams);
+                /*String method, String url*/
+                getRequestNoAuth(method, url);
         
         ApacheHttpClientRequest request = new ApacheHttpClientRequest(apacheRequest);
         

--- a/here-oauth-client/src/main/java/com/here/account/identity/bo/IdentityTokenRequest.java
+++ b/here-oauth-client/src/main/java/com/here/account/identity/bo/IdentityTokenRequest.java
@@ -1,0 +1,146 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.identity.bo;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import com.here.account.oauth2.AccessTokenRequest;
+
+public class IdentityTokenRequest extends AccessTokenRequest {
+    
+    public static final String IDENTITY_GRANT_TYPE = "identity";
+    
+    private String runAsId;
+    private String namespace;
+    private String runAsIdName;
+    private String podName;
+    private String podUid;
+    
+    public IdentityTokenRequest() {
+        super(IDENTITY_GRANT_TYPE);
+    }
+
+    public String getRunAsId() {
+        return runAsId;
+    }
+
+    public IdentityTokenRequest withRunAsId(String runAsId) {
+        this.runAsId = runAsId;
+        return this;
+    }
+
+    public String getNamespace() {
+        return namespace;
+    }
+
+    public IdentityTokenRequest withNamespace(String namespace) {
+        this.namespace = namespace;
+        return this;
+    }
+
+    public String getRunAsIdName() {
+        return runAsIdName;
+    }
+
+    public IdentityTokenRequest withRunAsIdName(String runAsIdName) {
+        this.runAsIdName = runAsIdName;
+        return this;
+    }
+
+    public String getPodName() {
+        return podName;
+    }
+
+    public IdentityTokenRequest withPodName(String podName) {
+        this.podName = podName;
+        return this;
+    }
+    
+    public String getPodUid() {
+        return podUid;
+    }
+    
+    public IdentityTokenRequest withPodUid(String podUid) {
+        this.podUid = podUid;
+        return this;
+    }
+
+    
+    private static final String RUN_AS_ID_FORM = "runAsId";
+    private static final String NAMESPACE_FORM = "namespace";
+    private static final String RUN_AS_ID_NAME_FORM = "runAsIdName";
+    private static final String POD_NAME_FORM = "podName";
+    private static final String POD_UID_FORM = "podUid";
+
+    /**
+     * Converts this request, to its formParams Map representation.
+     * 
+     * @return the formParams, for use with application/x-www-form-urlencoded bodies.
+     */
+    @Override
+    public Map<String, List<String>> toFormParams() {
+        Map<String, List<String>> formParams = super.toFormParams();
+        addFormParam(formParams, RUN_AS_ID_FORM, getRunAsId());
+        addFormParam(formParams, NAMESPACE_FORM, getNamespace());
+        addFormParam(formParams, RUN_AS_ID_NAME_FORM, getRunAsIdName());
+        addFormParam(formParams, POD_NAME_FORM, getPodName());
+        addFormParam(formParams, POD_UID_FORM, getPodUid());
+        return formParams;
+    }
+    
+    /**
+     * Converts the formParams generated from an instance of IdentityTokenRequest, 
+     * back into the IdentityTokenRequest with proper properties set.
+     * 
+     * @param formParams the formParams representing an IdentityTokenRequest
+     * @return the resulting IdentityTokenRequest
+     */
+    public static IdentityTokenRequest fromFormParams(Map<String, List<String>> formParams) {
+        IdentityTokenRequest identityTokenRequest = new IdentityTokenRequest()
+                .withRunAsId(getSingleFormValue(formParams, RUN_AS_ID_FORM))
+                .withNamespace(getSingleFormValue(formParams, NAMESPACE_FORM))
+                .withRunAsIdName(getSingleFormValue(formParams, RUN_AS_ID_NAME_FORM))
+                .withPodName(getSingleFormValue(formParams, POD_NAME_FORM))
+                .withPodUid(getSingleFormValue(formParams, POD_UID_FORM));
+        String expiresInString = getSingleFormValue(formParams, EXPIRES_IN_FORM);
+        if (null != expiresInString) {
+            Long expiresIn = Long.parseLong(expiresInString);
+            identityTokenRequest.setExpiresIn(expiresIn);
+        }
+        identityTokenRequest.setScope(getSingleFormValue(formParams, SCOPE_FORM));
+        return identityTokenRequest;
+    }
+    
+    /**
+     * If available, gets the first value matching the formParamKey from formParams.
+     * 
+     * @param formParams the form parameters
+     * @param formParamKey the key 
+     * @return the first form value for the key
+     */
+    protected static String getSingleFormValue(
+            Map<String, List<String>> formParams, String formParamKey) {
+        List<String> values = formParams.get(formParamKey);
+        if (null != values && values.size() > 0) {
+            return values.get(0);
+        }
+        return null;
+    }
+
+    
+}

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenException.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenException.java
@@ -17,7 +17,7 @@ package com.here.account.oauth2;
 
 /**
  * If you had trouble authenticating, and got an HTTP response, 
- * you get an AuthenticationException.
+ * you get an AccessTokenException.
  * This could be because the client or resource owner failed to 
  * properly authenticate a request to the authorization server, 
  * or because the request could not be fulfilled for some other 
@@ -26,7 +26,7 @@ package com.here.account.oauth2;
  * @author kmccrack
  *
  */
-public class AccessTokenException extends Exception {
+public class AccessTokenException extends RuntimeException {
 
     /**
      * default.

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenProvider.java
@@ -1,12 +1,12 @@
 /*
- * Copyright (c) 2016 HERE Europe B.V.
- * 
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
- * 
+ *
  *     http://www.apache.org/licenses/LICENSE-2.0
- * 
+ *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -16,9 +16,21 @@
 package com.here.account.oauth2;
 
 /**
- * A {@code ClientCredentialsProvider} identifies a token endpoint and provides
- * a mechanism to use credentials to authorize access token requests.
+ * An interface that lets you get Access Tokens, for use with HERE Services.
+ *
+ * <p>
+ * See <a href="https://tools.ietf.org/html/rfc6749#section-7.1">OAuth2.0</a>,
+ * and <a href="https://tools.ietf.org/html/rfc6750">OAuth2.0 Bearer Token Usage</a>
+ * for details.
+ *
+ * @author kmccrack
  */
-public interface ClientCredentialsProvider extends ClientAuthorizationRequestProvider {
-    
+public interface AccessTokenProvider {
+
+    /**
+     * Gets an OAuth2.0 Access Token.
+     *
+     * @return the access token
+     */
+    String getAccessToken();
 }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenRequest.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenRequest.java
@@ -20,6 +20,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.here.account.util.JacksonSerializer;
+
 /**
  * One of the OAuth2.0 
  * <a href="https://tools.ietf.org/html/rfc6749#section-1.3">Authorization Grant</a> Request 
@@ -32,16 +34,26 @@ public abstract class AccessTokenRequest {
     
     /**
      * expiresIn; the parameter name for "expires in" when conveyed in a JSON body.
+     * @deprecated use {@link JacksonSerializer} instead
      */
     private static final String EXPIRES_IN_JSON = "expiresIn";
     
     /**
      * expires_in; the parameter name for "expires in" when conveyed in a form body.
      */
-    private static final String EXPIRES_IN_FORM = "expires_in";
+    protected static final String EXPIRES_IN_FORM = "expires_in";
     
+    /**
+     * grantType; the parameter name for "grant type" when conveyed in a JSON body.
+     * @deprecated use {@link JacksonSerializer} instead
+     */
     protected static final String GRANT_TYPE_JSON = "grantType";
     protected static final String GRANT_TYPE_FORM = "grant_type";
+    
+    /**
+     * scope; the parameter name for "scope" when conveyed in a JSON body.
+     * @deprecated use {@link JacksonSerializer} instead
+     */
     protected static final String SCOPE_JSON = "scope";
     protected static final String SCOPE_FORM = "scope";
     
@@ -108,22 +120,34 @@ public abstract class AccessTokenRequest {
     }
 
     /**
-     * Get the scope for the token.
+     * Get the scope for the token request.  See also 
+     * <a href="http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims">
+     * Requesting Claims using Scope Values</a>.
+     * 
+     * <p>
      * The example value is "openid
      * sdp:GROUP-6bb1bfd9-8bdc-46c2-85cd-754068aa9497,
      * GROUP-84ba52de-f80b-4047-a024-33d81e6153df"
      * openid : Specifies the idToken is expected in the response
      * sdp:[List of groupId separated by ',']
+     * 
+     * @return the scope
      */
     public String getScope() {
         return this.scope;
     }
 
     /**
-     * Get the scope for the token.
+     * Set the scope for the token request.  See also 
+     * <a href="http://openid.net/specs/openid-connect-core-1_0.html#ScopeClaims">
+     * Requesting Claims using Scope Values</a>.
+     * 
+     * <p>
      * The example value is "openid
      * sdp:GROUP-6bb1bfd9-8bdc-46c2-85cd-754068aa9497,
-     * GROUP-84ba52de-f80b-4047-a024-33d81e6153df"
+     * GROUP-84ba52de-f80b-4047-a024-33d81e6153df".
+     * 
+     * @param scope the scope to set
      */
     public AccessTokenRequest setScope(String scope) {
         this.scope = scope;
@@ -134,7 +158,9 @@ public abstract class AccessTokenRequest {
      * Converts this request, into its JSON body representation.
      * 
      * @return the JSON body, for use with application/json bodies
+     * @deprecated use {@link JacksonSerializer} instead
      */
+    @Deprecated
     public String toJson() {
         return "{\"" + GRANT_TYPE_JSON + "\":\"" + getGrantType() + "\""
             + (null != expiresIn ? ",\"" + EXPIRES_IN_JSON + "\":" + expiresIn : "")

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider;
+
+/**
+ * A {@code ClientAuthorizationRequestProvider} identifies a token endpoint,
+ * provides a mechanism to use credentials to authorize access token requests,
+ * and provides access token request objects.
+ */
+public interface ClientAuthorizationRequestProvider {
+
+    /**
+     * Gets the url of the token endpoint for this OAuth 2.0 Provider.
+     * See also <a href="https://tools.ietf.org/html/rfc6749#section-3.2">The
+     * OAuth 2.0 Authorization Framework: Token Endpoint</a>.
+     * 
+     * @return the url of the token endpoint
+     */
+    String getTokenEndpointUrl();
+    
+    /**
+     * Gets the {@code HttpRequestAuthorizer} that the client will use
+     * to authorize access token requests.
+     * 
+     * @return the client authorizer
+     */
+    HttpProvider.HttpRequestAuthorizer getClientAuthorizer();
+    
+    /**
+     * Gets a new AccessTokenRequest to authorize this client to obtain 
+     * an Access Token.
+     * 
+     * @return the new Access Token Request
+     */
+    AccessTokenRequest getNewAccessTokenRequest();
+    
+    /**
+     * Get the HTTP Method used to obtain authorization.
+     * 
+     * @return the HTTP Method
+     */
+    HttpMethods getHttpMethod();
+    
+}

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/FileAccessTokenResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/FileAccessTokenResponse.java
@@ -1,0 +1,107 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+/**
+ * A FileAccessTokenResponse provides access to an Access Token 
+ * read from a File.  Because Files may have been written in the 
+ * past, the method {@link #getExp()} gives you the proper expiration time, 
+ * and {@link #getExpiresIn()} is dynamically computed to behave as though 
+ * you just got the response from a server.
+ * 
+ * @author kmccrack
+ *
+ */
+public class FileAccessTokenResponse extends AccessTokenResponse {
+
+    /**
+     * exp
+         The "exp" (expiration time) claim identifies the expiration time on
+   or after which the JWT MUST NOT be accepted for processing.
+     *
+     * <p>
+     * See also 
+     * <a href="https://tools.ietf.org/html/rfc7519#section-4.1.4">JSON Web Token (JWT):  &quot;exp&quot; (Expiration Time) Claim</a>.
+     * 
+     * <p>
+     * It is of type "NumericDate": 
+     *   A JSON numeric value representing the number of seconds from
+      1970-01-01T00:00:00Z UTC until the specified UTC date/time,
+      ignoring leap seconds.
+     * 
+     * <p>
+     * See also 
+     * <a href="https://tools.ietf.org/html/rfc7519#section-2">JSON Web Token (JWT):  Terminology</a>.
+     */
+    @JsonProperty("exp")
+    private final Long exp;
+    
+    public FileAccessTokenResponse() {
+        this(null, null, null, null,  null, null);
+    }
+    
+    public FileAccessTokenResponse(String accessToken, 
+            String tokenType,
+            Long expiresIn, String refreshToken, String idToken,
+            Long exp) {
+        super(accessToken, 
+            tokenType,
+            expiresIn, refreshToken, idToken);
+        
+        this.exp = exp;
+    }
+    
+    /**
+     * In a File-based Access Token Response, the access_token may have been written 
+     * long ago, and the appropriate expiresIn value is derived from the fixed quantity 
+     * "exp" seconds minus the time of this object creation in seconds.
+     * 
+     * <p>
+     * {@inheritDoc}
+     */
+    @Override
+    public Long getExpiresIn() {
+        return exp - (getStartTimeMilliseconds() / 1000);
+    }
+
+    /**
+     * exp
+         The "exp" (expiration time) claim identifies the expiration time on
+   or after which the JWT MUST NOT be accepted for processing.
+     *
+     * <p>
+     * See also 
+     * <a href="https://tools.ietf.org/html/rfc7519#section-4.1.4">JSON Web Token (JWT):  &quot;exp&quot; (Expiration Time) Claim</a>.
+     * 
+     * <p>
+     * It is of type "NumericDate": 
+     *   A JSON numeric value representing the number of seconds from
+      1970-01-01T00:00:00Z UTC until the specified UTC date/time,
+      ignoring leap seconds.
+     * 
+     * <p>
+     * See also 
+     * <a href="https://tools.ietf.org/html/rfc7519#section-2">JSON Web Token (JWT):  Terminology</a>.
+     * 
+     * @return the exp
+     */
+    public Long getExp() {
+        return exp;
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/Fresh.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/Fresh.java
@@ -15,13 +15,15 @@
  */
 package com.here.account.oauth2;
 
+import java.io.Closeable;
+
 /**
  * Wraps an object such that it is guaranteed to be "fresh" or always up to date.
  * The definition of "fresh" is implementation specific.
  * 
  * @param <T> the type of the represented object
  */
-public interface Fresh<T> {
+public interface Fresh<T> extends Closeable {
     
     /**
      * Get the most up to date version of the wrapped object.
@@ -29,4 +31,5 @@ public interface Fresh<T> {
      * @return a "fresh" version of the object
      */
     T get();
+
 }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccessTokenProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccessTokenProvider.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (c) 2017 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.function.Supplier;
+
+import com.here.account.auth.provider.ClientAuthorizationProviderChain;
+import com.here.account.http.HttpProvider;
+import com.here.account.http.apache.ApacheHttpClientProvider;
+
+/**
+ * An implementation to get HERE Access Tokens, that is configured using its Builder.
+ *
+ * @author kmccrack
+ */
+public class HereAccessTokenProvider implements AccessTokenProvider, Closeable {
+
+    /**
+     * Gets a new Builder for a HERE Access Token Provider.
+     *
+     * @return the Builder
+     * @see com.here.account.oauth2.HereAccessTokenProvider.Builder
+     */
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    /**
+     * By default the Builder uses
+     * <ul>
+     *     <li>System properties</li>
+     *     <li>~/.here/credentials.ini file</li>
+     *     <li>~/.here/credentials.properties file</li>
+     * </ul> for credentials,
+     * the ApacheHttpClientProvider,
+     * and the "always fresh" Access Token.
+     */
+    public static class Builder {
+        private ClientAuthorizationRequestProvider clientAuthorizationRequestProvider;
+        private HttpProvider httpProvider;
+        private boolean alwaysRequestNewToken = false;
+        
+        private Builder() {
+        }
+
+        /**
+         * Optionally set your custom ClientAuthorizationRequestProvider,
+         * to override the default.
+         *
+         * @param clientAuthorizationRequestProvider the clientAuthorizationRequestProvider to set
+         * @return this Builder
+         */
+        public Builder setClientAuthorizationRequestProvider(
+                ClientAuthorizationRequestProvider clientAuthorizationRequestProvider) {
+            this.clientAuthorizationRequestProvider = clientAuthorizationRequestProvider;
+            return this;
+        }
+
+        /**
+         * Optionally set your custom HttpProvider,
+         * to override the default.
+         *
+         * @param httpProvider the HttpProvider to set
+         * @return this Builder
+         */
+        public Builder setHttpProvider(HttpProvider httpProvider) {
+            this.httpProvider = httpProvider;
+            return this;
+        }
+
+        /**
+         * Default is false.
+         * It is not recommended to set this value to true, in a long-running
+         * application.
+         *
+         * Optionally set this value to true, to make a remote API call
+         * for every call to {@link HereAccessTokenProvider#getAccessToken()}.
+         *
+         * @param alwaysRequestNewToken default is false.  set to true to make
+         *        every call to get an Access Token, be a
+         *        remote API call.
+         * @return this Builder
+         */
+        public Builder setAlwaysRequestNewToken(boolean alwaysRequestNewToken) {
+            this.alwaysRequestNewToken = alwaysRequestNewToken;
+            return this;
+        }
+
+
+        /**
+         * Build using builders, builders, and more builders.
+         *
+         * @return the built HereAccessTokenProvider implementation for getting HERE Access Tokens.
+         */
+        public HereAccessTokenProvider build() {
+
+            if (null == clientAuthorizationRequestProvider) {
+                this.clientAuthorizationRequestProvider = 
+                        ClientAuthorizationProviderChain.DEFAULT_CLIENT_CREDENTIALS_PROVIDER_CHAIN;
+            }
+
+            boolean doCloseHttpProvider = false;
+            if (null == httpProvider) {
+                // uses PoolingHttpClientConnectionManager by default
+                this.httpProvider = ApacheHttpClientProvider.builder().build();
+                // because the httpProvider was not injected, we should close it
+                doCloseHttpProvider = true;
+            }
+
+            return new HereAccessTokenProvider(
+                    clientAuthorizationRequestProvider,
+                    httpProvider,
+                    doCloseHttpProvider,
+                    alwaysRequestNewToken);
+        }
+    }
+
+    private final HttpProvider httpProvider;
+    private final boolean doCloseHttpProvider;
+    private final TokenEndpoint tokenEndpoint;
+    private final Supplier<AccessTokenRequest> accessTokenRequestSupplier;
+    private final Fresh<AccessTokenResponse> fresh;
+
+
+    private HereAccessTokenProvider(ClientAuthorizationRequestProvider credentials, HttpProvider httpProvider,
+            boolean doCloseHttpProvider, boolean alwaysRequestNewToken) {
+        this.httpProvider = httpProvider;
+        this.doCloseHttpProvider = doCloseHttpProvider;
+        this.tokenEndpoint = HereAccount.getTokenEndpoint(httpProvider, credentials);
+        this.accessTokenRequestSupplier = () -> {
+            return credentials.getNewAccessTokenRequest();
+        };
+        if (alwaysRequestNewToken) {
+            // always request a new token
+            this.fresh = null;
+        } else {
+            // use the auto-refreshing technique
+            this.fresh = tokenEndpoint.requestAutoRefreshingToken(
+                    accessTokenRequestSupplier);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getAccessToken() {
+        return getAccessTokenResponse().getAccessToken();
+    }
+    
+    public AccessTokenResponse getAccessTokenResponse() {
+        if (null != fresh) {
+            return fresh.get();
+        } else {
+            return tokenEndpoint.requestToken(accessTokenRequestSupplier.get());
+        }
+
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void close() throws IOException {
+        try {
+            if (null != fresh) {
+                fresh.close();
+            }
+        } finally {
+            if (doCloseHttpProvider && null != httpProvider) {
+                httpProvider.close();
+            }
+        }
+    }
+}

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/RequestExecutionException.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/RequestExecutionException.java
@@ -19,7 +19,7 @@ package com.here.account.oauth2;
  * A RequestExecutionException occurs when there is a problem processing a
  * request made to an HTTP endpoint.
  */
-public class RequestExecutionException extends Exception {
+public class RequestExecutionException extends RuntimeException {
 
     /**
      * Creates a new instance of <code>RequestExecutionException</code> without

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ResponseParsingException.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ResponseParsingException.java
@@ -19,7 +19,7 @@ package com.here.account.oauth2;
  * A ResponseParsingException occurs when there is a problem parsing a response
  * received from an HTTP request.
  */
-public class ResponseParsingException extends Exception {
+public class ResponseParsingException extends RuntimeException {
 
     /**
      * Creates a new instance of <code>ResponseParsingException</code> without

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/TokenEndpoint.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/TokenEndpoint.java
@@ -15,6 +15,8 @@
  */
 package com.here.account.oauth2;
 
+import java.util.function.Supplier;
+
 /**
  * A {@code TokenEndpoint} directly corresponds to the token endpoint as specified in
  * the OAuth2.0 Specification.  See
@@ -57,5 +59,25 @@ public interface TokenEndpoint {
      */
     Fresh<AccessTokenResponse> requestAutoRefreshingToken(AccessTokenRequest request) 
             throws AccessTokenException, RequestExecutionException, ResponseParsingException;
+    
+    /**
+     * POST to the token endpoint to get an always fresh HERE Access Token, for use with HERE Services.
+     * The returned token is wrapped in a {@link Fresh}, and is periodically and automatically
+     * refreshed before it expires.  The token can be used as an Authorization: Bearer token value.
+     * See <a href="https://tools.ietf.org/html/rfc6749#section-7.1">OAuth2.0</a>, 
+     * and <a href="https://tools.ietf.org/html/rfc6750">OAuth2.0 Bearer Token Usage</a> 
+     * for details.
+     *
+     * @param requestSupplier a Supplier of token requests, to be used for each attempt to get a fresh token.
+     * @return a {@link Fresh} wrapped Access Token that can be used as Bearer token for HERE Service requests
+     *         the returned {@link Fresh} will always give an unexpired access token on a call to get()
+     * @throws AccessTokenException if you had trouble authenticating your request to the authorization server, 
+     *      or the authorization server rejected your request
+     * @throws RequestExecutionException if trouble processing the request
+     * @throws ResponseParsingException if trouble parsing the response
+     */
+    Fresh<AccessTokenResponse> requestAutoRefreshingToken(Supplier<AccessTokenRequest> requestSupplier) 
+            throws AccessTokenException, RequestExecutionException, ResponseParsingException;
+
                                                                 
 }

--- a/here-oauth-client/src/main/java/com/here/account/util/JacksonSerializer.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/JacksonSerializer.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.util;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+
+/**
+ * A Serializer that uses Jackson to serialize and deserialize JSON.
+ *
+ * @author kmccrack
+ */
+public class JacksonSerializer implements Serializer {
+
+    public JacksonSerializer() {
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    public Map<String, Object> jsonToMap(InputStream jsonInputStream) {
+        try {
+            return JsonSerializer.toMap(jsonInputStream);
+        } catch (IOException e) {
+            throw new RuntimeException("trouble deserializing json: " + e, e);
+        }
+    }
+
+    @Override
+    public <T> T jsonToPojo(InputStream jsonInputStream, Class<T> pojoClass) {
+        try {
+            return JsonSerializer.toPojo(jsonInputStream, pojoClass);
+        } catch (IOException e) {
+            throw new RuntimeException("trouble deserializing json: " + e, e);
+        }
+    }
+
+    @Override
+    public String objectToJson(Object object) {
+        try {
+            return JsonSerializer.objectToJson(object);
+        } catch (JsonProcessingException e) {
+            throw new RuntimeException("trouble serializing json: " + e, e);
+        }
+    }
+
+    @Override
+    public void writeObjectToJson(OutputStream outputStream, Object object) {
+        try {
+            JsonSerializer.writeObjectToJson(outputStream, object);
+        } catch (IOException e) {
+            throw new RuntimeException("trouble serializing json: " + e, e);
+        }
+    }
+    
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/util/JsonSerializer.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/JsonSerializer.java
@@ -17,11 +17,13 @@ package com.here.account.util;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.charset.Charset;
 import java.util.HashMap;
 import java.util.Map;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.core.JsonGenerationException;
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
@@ -100,6 +102,19 @@ public class JsonSerializer {
      */
     public static String objectToJson(Object object) throws JsonProcessingException {
         return objectMapper.writeValueAsString(object);
+    }
+    
+    /**
+     * Writes the object to the specified outputStream as JSON.
+     * 
+     * @param outputStream the OutputStream to which to write
+     * @param object the object to write to the stream
+     * @throws JsonGenerationException if trouble serializing
+     * @throws JsonMappingException if trouble serializing
+     * @throws IOException if I/O trouble writing to the stream
+     */
+    static void writeObjectToJson(OutputStream outputStream, Object object) throws JsonGenerationException, JsonMappingException, IOException {
+        objectMapper.writeValue(outputStream, object);
     }
 
 }

--- a/here-oauth-client/src/main/java/com/here/account/util/ReadUtil.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/ReadUtil.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.util;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class ReadUtil {
+
+    /**
+     * 16 Kilobytes.
+     */
+    private final static int MAX_BYTES_TO_READ = 1024*16;
+    
+    public static byte[] readUpTo16KBytes(InputStream inputStream) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        byte[] buf = new byte[4096];
+        int numRead;
+        int totalRead = 0;
+        while (totalRead < MAX_BYTES_TO_READ && (numRead = inputStream.read(buf)) > 0) {
+            baos.write(buf, 0, numRead);
+            totalRead += numRead;
+        }
+        return baos.toByteArray();
+    }
+}

--- a/here-oauth-client/src/main/java/com/here/account/util/RefreshableResponseProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/RefreshableResponseProvider.java
@@ -122,18 +122,24 @@ public class RefreshableResponseProvider<T extends ExpiringResponse> {
   public RefreshableResponseProvider(
           final Clock clock,
           final Long refreshIntervalMillis,
-          final T initialToken,
+          final T initialResponse,
           final ResponseRefresher<T> refreshTokenFunction,
           final ScheduledExecutorService scheduledExecutorService
       ) {
       Objects.requireNonNull(clock, "clock cannot be null");
-      Objects.requireNonNull(initialToken, "initialToken cannot be null");
+      Objects.requireNonNull(initialResponse, "initialResponse cannot be null");
       Objects.requireNonNull(refreshTokenFunction, "refreshTokenFunction cannot be null");
       Objects.requireNonNull(scheduledExecutorService, "scheduledExecutorService cannot be null");
       
+      // expires_in cannot be null
+      Objects.requireNonNull(initialResponse.getExpiresIn(), 
+              "initialResponse.getExpiresIn() cannot be null");
+      Objects.requireNonNull(initialResponse.getStartTimeMilliseconds(), 
+              "initialResponse.getStartTimeMilliseconds() cannot be null");
+      
       this.clock = clock;
       this.refreshIntervalMillis = refreshIntervalMillis;
-      this.refreshToken = initialToken;
+      this.refreshToken = initialResponse;
       this.refreshTokenFunction = refreshTokenFunction;
 
       this.scheduledExecutorService = scheduledExecutorService;

--- a/here-oauth-client/src/main/java/com/here/account/util/Serializer.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/Serializer.java
@@ -1,0 +1,24 @@
+package com.here.account.util;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+
+public interface Serializer {
+    
+    /**
+     * Reads from the input jsonInputStream containing bytes from a JSON stream, 
+     * and returns the corresponding Map&lt;String, Object&gt;.
+     * 
+     * @param jsonInputStream the input stream
+     * @return the corresponding deserialized Map&lt;String, Object&gt;
+     */
+    Map<String, Object> jsonToMap(InputStream jsonInputStream);
+    
+    <T> T jsonToPojo (InputStream jsonInputStream, Class<T> pojoClass);
+    
+    String objectToJson(Object object);
+    
+    void writeObjectToJson(OutputStream outputStream, Object object);
+
+}

--- a/here-oauth-client/src/main/javadoc/overview.html
+++ b/here-oauth-client/src/main/javadoc/overview.html
@@ -18,9 +18,18 @@
         // use hereAccessToken on requests until expires...
    }
    </pre>
-        
+   <p>
+      See the {@link com.here.account.oauth2.HereAccount} entry point class for detailed usage instructions.
         <p>
-            See the {@link com.here.account.oauth2.HereAccount} entry point class for detailed usage instructions.
-            
+   To use your credentials in system properties, credentials.ini file or credentials.properties in that order, and get a token:
+        <pre>
+          {@code
+             HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder().build()
+             String accessToken = accessTokens.getAccessToken();
+
+            }
+        </pre>
+        <p>
+            See the {@link com.here.account.oauth2.HereAccessTokenProvider} entry point class for detailed usage instructions.
     </body>
 </html>

--- a/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
@@ -120,8 +120,7 @@ public class OAuth1SignerTest {
             }
         }
     }
-    
-    
+
     @Test
     public void test_sign_formParams_impactsSignature() {
         Map<String, List<String>> formParams = null;
@@ -176,7 +175,6 @@ public class OAuth1SignerTest {
         assertTrue("sig256 was null for HmacSHA256", null != sig256);
         
         assertTrue("sig1 "+sig1+" wasn't smaller than sig256 "+sig256, sig1.length() < sig256.length());
-
     }
     
     @Test
@@ -253,6 +251,4 @@ public class OAuth1SignerTest {
         //return new Base64().encodeAsString(signatureBytes);
         return Base64.encodeBase64String(signatureBytes);
     }
-
-
 }

--- a/here-oauth-client/src/test/java/com/here/account/auth/SignatureCalculatorTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/SignatureCalculatorTest.java
@@ -212,7 +212,7 @@ public class SignatureCalculatorTest {
         assertTrue(SignatureCalculator.verifySignature(cipherText, SignatureMethod.ES512, signature, publicKeyBase64));
     }
 
-    private static KeyPair generateES512KeyPair()  {
+    public static KeyPair generateES512KeyPair()  {
         try {
             ECGenParameterSpec ecGenParameterSpec = new ECGenParameterSpec("secp521r1");
             KeyPairGenerator kpg = KeyPairGenerator.getInstance(ELLIPTIC_CURVE_ALGORITHM);

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/ClientAuthorizationProviderChainTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/ClientAuthorizationProviderChainTest.java
@@ -1,0 +1,178 @@
+package com.here.account.auth.provider;
+
+import com.here.account.auth.OAuth1ClientCredentialsProvider;
+import com.here.account.http.HttpConstants;
+import com.here.account.http.HttpProvider;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.oauth2.ClientCredentialsGrantRequest;
+import org.junit.After;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+public class ClientAuthorizationProviderChainTest {
+
+    String expectedTokenEndpointUrl1 = "expectedTokenEndpointUrl1";
+    String expectedAccessKeyId1 = "expectedAccessKeyId1";
+    String expectedAccessKeySecret1 = "accessKeySecret1";
+
+    String tokenEndpointUrl;
+    String accessKeyId;
+    String accessKeySecret;
+    File file;
+
+    protected void createTmpFile() throws IOException {
+        String prefix = UUID.randomUUID().toString();
+        file = File.createTempFile(prefix, null);
+        file.deleteOnExit();
+    }
+
+    @After
+    public void tearDown() {
+        if (null != file) {
+            file.delete();
+        }
+        restoreSystemProperties();
+    }
+
+    public ClientAuthorizationRequestProvider getClientAuthorizationRequestProviderFromIniFile() throws Exception {
+        createTmpFile();
+        FromHereCredentialsIniStreamTest test = new FromHereCredentialsIniStreamTest();
+        byte[] bytes = test.getDefaultIniStreamContents();
+        try (OutputStream outputStream = new FileOutputStream(file)) {
+            outputStream.write(bytes);
+            outputStream.flush();
+        }
+        return new FromHereCredentialsIniFile(file, FromHereCredentialsIniStreamTest.TEST_DEFAULT_INI_SECTION_NAME);
+    }
+
+    public ClientAuthorizationRequestProvider getClientAuthorizationRequestProviderFromIniFileWithNoPropertiesSet() throws Exception {
+        createTmpFile();
+        return new FromHereCredentialsIniFile(file, FromHereCredentialsIniStreamTest.TEST_DEFAULT_INI_SECTION_NAME);
+    }
+
+    public ClientAuthorizationRequestProvider getClientAuthorizationRequestProviderFromSystemProperties() {
+        tokenEndpointUrl = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY);
+        accessKeyId = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY);
+        accessKeySecret = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY);
+
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, expectedTokenEndpointUrl1);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY, expectedAccessKeyId1);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY, expectedAccessKeySecret1);
+
+        return  new FromSystemProperties();
+    }
+
+    public ClientAuthorizationRequestProvider getClientAuthorizationRequestProviderFromSystemPropertiesWithNoPropertiesSet() {
+        tokenEndpointUrl = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY);
+        accessKeyId = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY);
+        accessKeySecret = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY);
+
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, "");
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY, "");
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY, "");
+
+        return  new FromSystemProperties();
+    }
+
+
+    public void restoreSystemProperties() {
+        // there's no way to undo a System.setProperty(a, b) if a was previously null
+        // the best we can do is a ""
+        if (null == tokenEndpointUrl) {
+            tokenEndpointUrl = "";
+        }
+        if (null == accessKeyId) {
+            accessKeyId = "";
+        }
+        if (null == accessKeySecret) {
+            accessKeySecret = "";
+        }
+
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, tokenEndpointUrl);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY, accessKeyId);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY, accessKeySecret);
+    }
+
+    public ClientAuthorizationRequestProvider getClientAuthorizationRequestProviderFromHerePropertiesFile() throws Exception {
+        return new FromDefaultHereCredentialsPropertiesFile();
+    }
+
+    @Test
+    public void test_DefaultProviderChain() throws Exception{
+
+        ClientAuthorizationRequestProvider fromSystemProperties = getClientAuthorizationRequestProviderFromSystemProperties();
+        ClientAuthorizationRequestProvider fromIniFile = getClientAuthorizationRequestProviderFromIniFile();
+        ClientAuthorizationRequestProvider fromPropertiesFile = getClientAuthorizationRequestProviderFromHerePropertiesFile();
+
+        ClientAuthorizationProviderChain providerChain = new ClientAuthorizationProviderChain
+                (fromSystemProperties, fromIniFile, fromPropertiesFile);
+
+       verifyExpected(providerChain, fromSystemProperties);
+    }
+
+    @Test
+    public void test_DefaultProviderChain_defaultingToIni() throws Exception{
+
+        ClientAuthorizationRequestProvider fromSystemProperties = getClientAuthorizationRequestProviderFromSystemPropertiesWithNoPropertiesSet();
+        ClientAuthorizationRequestProvider fromIniFile = getClientAuthorizationRequestProviderFromIniFile();
+        ClientAuthorizationRequestProvider fromPropertiesFile = getClientAuthorizationRequestProviderFromHerePropertiesFile();
+
+        ClientAuthorizationProviderChain providerChain = new ClientAuthorizationProviderChain
+                (fromSystemProperties, fromIniFile, fromPropertiesFile);
+
+        verifyExpected(providerChain, fromIniFile);
+    }
+
+    @Test
+    public void test_DefaultProviderChain_defaultingToProperties() throws Exception{
+
+        ClientAuthorizationRequestProvider fromSystemProperties = getClientAuthorizationRequestProviderFromSystemPropertiesWithNoPropertiesSet();
+        ClientAuthorizationRequestProvider fromIniFile = getClientAuthorizationRequestProviderFromIniFileWithNoPropertiesSet();
+        ClientAuthorizationRequestProvider fromPropertiesFile = getClientAuthorizationRequestProviderFromHerePropertiesFile();
+
+        ClientAuthorizationProviderChain providerChain = new ClientAuthorizationProviderChain
+                (fromSystemProperties, fromIniFile, fromPropertiesFile);
+
+        verifyExpected(providerChain, fromPropertiesFile);
+    }
+
+    protected void verifyExpected(ClientAuthorizationProviderChain providerChain, ClientAuthorizationRequestProvider
+                                  clientAuthorizationRequestProvider) {
+
+        String expectedTokenEndpointUrl = clientAuthorizationRequestProvider.getTokenEndpointUrl();
+        String actualTokenEndpointUrl = providerChain.getTokenEndpointUrl();
+
+        assertTrue("tokenEndpointUrl expected "+expectedTokenEndpointUrl+", actual "+ actualTokenEndpointUrl,
+                expectedTokenEndpointUrl.equals(actualTokenEndpointUrl));
+        assertTrue("httpMethod was expected to be POST", providerChain.getHttpMethod() == HttpConstants.HttpMethods.POST);
+
+        HttpProvider.HttpRequestAuthorizer httpRequestAuthorizer = providerChain.getClientAuthorizer();
+        assertTrue("httpRequestAuthorizer was null", null != httpRequestAuthorizer);
+        // the authorizer must append an Authorization header in the OAuth scheme.
+        HttpProvider.HttpRequest httpRequest = mock(HttpProvider.HttpRequest.class);
+
+        String method = "GET";
+        String url = "https://www.example.com/foo";
+        Map<String, List<String>> formParams = null;
+        httpRequestAuthorizer.authorize(httpRequest, method, url, formParams);
+
+        verify(httpRequest, times(1)).addAuthorizationHeader(
+                Mockito.matches("\\AOAuth .+\\z"));
+        assertTrue("grantType should equal " + ClientCredentialsGrantRequest.CLIENT_CREDENTIALS_GRANT_TYPE,
+                providerChain.getNewAccessTokenRequest().getGrantType().equals(ClientCredentialsGrantRequest.CLIENT_CREDENTIALS_GRANT_TYPE));
+
+    }
+}

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/FromDefaultHereCredentialsPropertiesFileExposer.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/FromDefaultHereCredentialsPropertiesFileExposer.java
@@ -1,0 +1,10 @@
+package com.here.account.auth.provider;
+
+import java.io.File;
+
+public class FromDefaultHereCredentialsPropertiesFileExposer {
+
+    public static File getDefaultHereCredentialsFile() {
+        return FromDefaultHereCredentialsPropertiesFile.getDefaultHereCredentialsFile();
+    }
+}

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/FromHereCredentialsIniFileTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/FromHereCredentialsIniFileTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.UUID;
+
+import org.junit.After;
+import org.junit.Test;
+
+import com.here.account.http.HttpConstants.HttpMethods;
+
+/**
+ * @author kmccrack
+ */
+public class FromHereCredentialsIniFileTest {
+    
+    File file;
+    FromHereCredentialsIniFile fromFile;
+    
+    protected void createTmpFile() throws IOException {
+        String prefix = UUID.randomUUID().toString();
+        file = File.createTempFile(prefix, null);
+        file.deleteOnExit();
+    }
+    
+    @After
+    public void tearDown() {
+        if (null != file) {
+            file.delete();
+        }
+    }
+    
+    @Test(expected = NullPointerException.class)
+    public void test_null_file() {
+        fromFile = new FromHereCredentialsIniFile(null, FromHereCredentialsIniStreamTest.TEST_DEFAULT_INI_SECTION_NAME);
+    }
+    
+    @Test(expected = RuntimeException.class)
+    public void test_nonExistant_file() {
+        fromFile = new FromHereCredentialsIniFile(new File(UUID.randomUUID().toString()), FromHereCredentialsIniStreamTest.TEST_DEFAULT_INI_SECTION_NAME);
+        fromFile.getTokenEndpointUrl();
+    }
+    
+    @Test
+    public void test_default_file() {
+        fromFile = new FromHereCredentialsIniFile();
+        File actualFile = fromFile.getFile();
+        String actualName = actualFile.getName();
+        String expectedName = "credentials.ini";
+        assertTrue("default file name expected "+expectedName+", actual "+actualName, expectedName.equals(actualName));
+    }
+
+
+    @Test
+    public void test_basic_file() throws IOException {
+        createTmpFile();
+        
+        FromHereCredentialsIniStreamTest otherTezt = new FromHereCredentialsIniStreamTest();
+        byte[] bytes = otherTezt.getDefaultIniStreamContents();
+        
+        try (OutputStream outputStream = new FileOutputStream(file)) {
+            outputStream.write(bytes);
+            outputStream.flush();
+        }
+        
+        // use the file
+        fromFile = new FromHereCredentialsIniFile(file, FromHereCredentialsIniStreamTest.TEST_DEFAULT_INI_SECTION_NAME);
+        otherTezt.verifyExpected(fromFile);
+    }
+    
+    @Test
+    public void test_getHttpMethod() {
+        fromFile = new FromHereCredentialsIniFile();
+        HttpMethods httpMethod = fromFile.getHttpMethod();
+        HttpMethods expectedHttpMethod = HttpMethods.POST;
+        assertTrue("httpMethod expected " + expectedHttpMethod + ", actual " + httpMethod,
+                expectedHttpMethod.equals(httpMethod));
+    }
+
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/FromHereCredentialsIniStreamTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/FromHereCredentialsIniStreamTest.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.http.HttpProvider.HttpRequest;
+import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+
+public class FromHereCredentialsIniStreamTest {
+
+    // the constants are copied in this file to represent files that have already been issued, 
+    // as canary tests to defend against unexpected changes in the code respect to file formats.
+    
+    static final String TEST_DEFAULT_INI_SECTION_NAME = "default";
+    private static final String TEST_TOKEN_ENDPOINT_URL_PROPERTY = "here.token.endpoint.url";
+    private static final String TEST_ACCESS_KEY_ID_PROPERTY = "here.access.key.id";
+    private static final String TEST_ACCESS_KEY_SECRET_PROPERTY = "here.access.key.secret";
+
+    private static final String SECTION_START = "[";
+    private static final String SECTION_END = "]";
+    private static final char NEWLINE = '\n';
+    private static final char EQUALS = '=';
+    
+    private String tokenEndpointUrl = "tokenEndpointUrl";
+    private String expectedTokenEndpointUrl = tokenEndpointUrl;
+    private String accessKeyId = "accessKeyId";
+    private String accessKeySecret = "accessKeySecret";
+    
+    FromHereCredentialsIniStream fromHereCredentialsIniStream;
+    
+    @Test(expected = NullPointerException.class)
+    public void test_basic_null_stream() {
+        fromHereCredentialsIniStream = new FromHereCredentialsIniStream(null);
+    }
+    
+    @Test(expected = RuntimeException.class)
+    public void test_basic_IOException_stream() {
+        InputStream inputStream = new InputStream() {
+
+            @Override
+            public int read() throws IOException {
+                throw new IOException("socket broken");
+            }
+            
+        };
+        fromHereCredentialsIniStream = new FromHereCredentialsIniStream(inputStream);
+    }
+
+    protected byte[] getDefaultIniStreamContents() {
+        StringBuilder buf = new StringBuilder()
+                .append(SECTION_START)
+                .append(TEST_DEFAULT_INI_SECTION_NAME)
+                .append(SECTION_END)
+                .append(NEWLINE)
+                
+                .append(TEST_TOKEN_ENDPOINT_URL_PROPERTY)
+                .append(EQUALS)
+                .append(tokenEndpointUrl)
+                .append(NEWLINE)
+                
+                .append(TEST_ACCESS_KEY_ID_PROPERTY)
+                .append(EQUALS)
+                .append(accessKeyId)
+                .append(NEWLINE)
+                
+                .append(TEST_ACCESS_KEY_SECRET_PROPERTY)
+                .append(EQUALS)
+                .append(accessKeySecret)
+                .append(NEWLINE)
+                ;
+        
+        return buf.toString().getBytes(StandardCharsets.UTF_8);
+    }
+    
+    @Test
+    public void test_basic_default_stream() throws IOException {
+       
+        try (InputStream inputStream = new ByteArrayInputStream(
+                getDefaultIniStreamContents()))
+        {
+            fromHereCredentialsIniStream = new FromHereCredentialsIniStream(inputStream);
+            verifyExpected(fromHereCredentialsIniStream);
+        }
+    }
+    
+    protected void verifyExpected(ClientAuthorizationRequestProvider clientAuthorizationRequestProvider) {
+        String actualTokenEndpointUrl = clientAuthorizationRequestProvider.getTokenEndpointUrl();
+        assertTrue("tokenEndpointUrl expected "+expectedTokenEndpointUrl+", actual "+actualTokenEndpointUrl, 
+                expectedTokenEndpointUrl.equals(actualTokenEndpointUrl));
+        
+        HttpRequestAuthorizer httpRequestAuthorizer = clientAuthorizationRequestProvider.getClientAuthorizer();
+        assertTrue("httpRequestAuthorizer was null", null != httpRequestAuthorizer);
+        
+        // the authorizer must append an Authorization header in the OAuth scheme.
+        HttpRequest httpRequest = mock(HttpRequest.class);
+
+        String method = "GET";
+        String url = "https://www.example.com/foo";
+        Map<String, List<String>> formParams = null;
+        httpRequestAuthorizer.authorize(httpRequest, method, url, formParams);
+
+        verify(httpRequest, times(1)).addAuthorizationHeader(
+                Mockito.matches("\\AOAuth .+\\z"));
+    }
+    
+    @Test
+    public void test_getHttpMethod() throws IOException {
+        test_basic_default_stream();
+        HttpMethods httpMethod = fromHereCredentialsIniStream.getHttpMethod();
+        HttpMethods expectedHttpMethod = HttpMethods.POST;
+        assertTrue("httpMethod expected " + expectedHttpMethod + ", actual " + httpMethod,
+                expectedHttpMethod.equals(httpMethod));
+    }
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/FromSystemPropertiesTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/FromSystemPropertiesTest.java
@@ -1,0 +1,103 @@
+package com.here.account.auth.provider;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.here.account.http.HttpProvider;
+import com.here.account.http.HttpConstants.HttpMethods;
+import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.here.account.auth.OAuth1ClientCredentialsProvider;
+import org.mockito.Mockito;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+
+public class FromSystemPropertiesTest {
+
+    private static final String TEST_TOKEN_ENDPOINT_URL_PROPERTY = "here.token.endpoint.url";
+    private static final String TEST_DEFAULT_TOKEN_ENDPOINT_URL = "https://account.api.here.com/oauth2/token";
+    FromSystemProperties fromSystemProperties;
+    
+    String expectedTokenEndpointUrl = "expectedTokenEndpointUrl";
+    String expectedAccessKeyId = "expectedAccessKeyId";
+    String expectedAccessKeySecret = "accessKeySecret";
+    
+    String tokenEndpointUrl;
+    String accessKeyId;
+    String accessKeySecret;
+    
+    @Before
+    public void setUp() {
+        tokenEndpointUrl = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY);
+        accessKeyId = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY);
+        accessKeySecret = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY);
+
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, expectedTokenEndpointUrl);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY, expectedAccessKeyId);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY, expectedAccessKeySecret);
+    }
+    
+    @After
+    public void tearDown() {
+        // there's no way to undo a System.setProperty(a, b) if a was previously null
+        // the best we can do is a ""
+        if (null == tokenEndpointUrl) {
+            tokenEndpointUrl = "";
+        }
+        if (null == accessKeyId) {
+            accessKeyId = "";
+        }
+        if (null == accessKeySecret) {
+            accessKeySecret = "";
+        }
+        
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, tokenEndpointUrl);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY, accessKeyId);
+        System.setProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY, accessKeySecret);
+
+    }
+    
+    @Test
+    public void test_properties() {
+        fromSystemProperties = new FromSystemProperties();
+        verifyExpected(fromSystemProperties);
+
+    }
+
+    protected void verifyExpected(ClientAuthorizationRequestProvider clientCredentialsProvider) {
+        String actualTokenEndpointUrl = clientCredentialsProvider.getTokenEndpointUrl();
+        assertTrue("tokenEndpointUrl expected "+expectedTokenEndpointUrl+", actual "+actualTokenEndpointUrl,
+                expectedTokenEndpointUrl.equals(actualTokenEndpointUrl));
+
+        HttpProvider.HttpRequestAuthorizer httpRequestAuthorizer = clientCredentialsProvider.getClientAuthorizer();
+        assertTrue("httpRequestAuthorizer was null", null != httpRequestAuthorizer);
+
+        // the authorizer must append an Authorization header in the OAuth scheme.
+        HttpProvider.HttpRequest httpRequest = mock(HttpProvider.HttpRequest.class);
+
+        String method = "GET";
+        String url = "https://www.example.com/foo";
+        Map<String, List<String>> formParams = null;
+        httpRequestAuthorizer.authorize(httpRequest, method, url, formParams);
+
+        verify(httpRequest, times(1)).addAuthorizationHeader(
+                Mockito.matches("\\AOAuth .+\\z"));
+    }
+    
+    @Test
+    public void test_getHttpMethod() throws IOException {
+        test_properties();
+        HttpMethods httpMethod = fromSystemProperties.getHttpMethod();
+        HttpMethods expectedHttpMethod = HttpMethods.POST;
+        assertTrue("httpMethod expected " + expectedHttpMethod + ", actual " + httpMethod,
+                expectedHttpMethod.equals(httpMethod));
+    }
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/incubator/RunAsIdAuthorizationProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/incubator/RunAsIdAuthorizationProviderTest.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth.provider.incubator;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.here.account.auth.provider.incubator.RunAsIdAuthorizationProvider;
+import com.here.account.http.HttpException;
+import com.here.account.http.HttpProvider;
+import com.here.account.http.HttpProvider.HttpResponse;
+import com.here.account.oauth2.HereAccessTokenProvider;
+
+public class RunAsIdAuthorizationProviderTest {
+
+    private RunAsIdAuthorizationProvider runAsIdAuthorizationProvider;
+
+    String accessToken;
+    HttpProvider httpProvider;
+    
+    @Before
+    public void setUp() throws IOException, HttpException {
+        httpProvider = Mockito.mock(HttpProvider.class);
+        HttpResponse httpResponse = Mockito.mock(HttpResponse.class);
+        
+        accessToken = "h1.foo.bar";
+        
+        byte[] content = ("{\"access_token\":\""+accessToken+"\",\"expires_in\":120}").getBytes(StandardCharsets.UTF_8);
+        long contentLength = content.length;
+        InputStream inputStream = 
+                new ByteArrayInputStream(
+                content
+                );
+        Mockito.when(httpResponse.getStatusCode()).thenReturn(200);
+        Mockito.when(httpResponse.getContentLength()).thenReturn(contentLength);
+        Mockito.when(httpResponse.getResponseBody()).thenReturn(inputStream);
+        Mockito.when(httpProvider.execute(Mockito.any())).thenReturn(httpResponse);
+
+        runAsIdAuthorizationProvider = new RunAsIdAuthorizationProvider();
+
+    }
+    
+    @Test
+    public void test_url() {
+        String tokenEndpointUrl = runAsIdAuthorizationProvider.getTokenEndpointUrl();
+        String expectedTokenEndpointUrl = "http://localhost:8001/token";
+        assertTrue("expected tokenEndpointUrl " + expectedTokenEndpointUrl + ", actual " + tokenEndpointUrl, 
+                expectedTokenEndpointUrl.equals(tokenEndpointUrl));
+    }
+    
+    @Test
+    public void test_getTokenEndpointUrl_different() {
+        String expectedTokenEndpointUrl = "http://www.example.com/token";
+        runAsIdAuthorizationProvider = new RunAsIdAuthorizationProvider(expectedTokenEndpointUrl);
+        String actualTokenEndpointUrl = runAsIdAuthorizationProvider.getTokenEndpointUrl();
+        assertTrue("expected tokenEndpointUrl " + expectedTokenEndpointUrl
+                + ", actual " + actualTokenEndpointUrl, 
+                expectedTokenEndpointUrl.equals(actualTokenEndpointUrl));
+    }
+    
+    @Test
+    public void test_HereAccessTokenProvider() {
+        HereAccessTokenProvider hereAccessTokenProvider = 
+                HereAccessTokenProvider.builder()
+                .setClientAuthorizationRequestProvider(runAsIdAuthorizationProvider)
+                .setHttpProvider(httpProvider)
+                .setAlwaysRequestNewToken(true)
+                .build();
+        String actualAccessToken = hereAccessTokenProvider.getAccessToken();
+        assertTrue("actualAccessToken was null", null != actualAccessToken);
+        assertTrue("actualAccessToken was blank", actualAccessToken.trim().length() > 0);
+        
+        assertTrue("expected accessToken " + accessToken + ", actual " + actualAccessToken, 
+                accessToken.equals(actualAccessToken));
+        
+
+    }
+    
+}

--- a/here-oauth-client/src/test/java/com/here/account/client/ClientTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/client/ClientTest.java
@@ -1,0 +1,248 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.here.account.http.HttpException;
+import com.here.account.http.HttpProvider;
+import com.here.account.oauth2.AccessTokenException;
+import com.here.account.oauth2.ErrorResponse;
+import com.here.account.oauth2.RequestExecutionException;
+import com.here.account.oauth2.ResponseParsingException;
+import com.here.account.util.JacksonSerializer;
+import com.here.account.util.Serializer;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.io.UnsupportedEncodingException;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+
+class FakeResponse {
+    @JsonProperty("access_token")
+    private final String accessToken;
+    @JsonProperty("token_type")
+    private final String tokenType;
+
+    public FakeResponse() {
+        this(null, null);
+    }
+
+    public FakeResponse(String accessToken, String tokenType) {
+        this.accessToken = accessToken;
+        this.tokenType = tokenType;
+    }
+
+    public String getAccessToken() {
+        return this.accessToken;
+    }
+
+    public String getTokenType() {
+        return this.tokenType;
+    }
+}
+
+class FakeRequest {
+    @JsonProperty
+    private final String clientId;
+
+    @JsonProperty
+    private final String scope;
+
+    @JsonProperty
+    private final String grantType;
+
+    public FakeRequest(String clientId, String scope, String grantType) {
+        this.clientId = clientId;
+        this.scope = scope;
+        this.grantType = grantType;
+    }
+
+    public String getClientId() {
+        return this.clientId;
+    }
+
+    public String getRequestField() {
+        return this.scope;
+    }
+
+    public String getGrantType() {
+        return this.grantType;
+    }
+}
+
+public class ClientTest {
+
+    Serializer serializer = new JacksonSerializer();
+    HttpProvider.HttpRequest mockHttpRequest;
+    HttpProvider mockHttpProvider;
+    HttpProvider.HttpRequestAuthorizer mockHttpRequestAuthorizer;
+    FakeResponse expectedResponseObject;
+
+    @Before
+    public void setUp() throws IOException, HttpException {
+        mockHttpRequest = mock(HttpProvider.HttpRequest.class);
+        mockHttpProvider = mock(HttpProvider.class);
+        mockHttpRequestAuthorizer = mock(HttpProvider.HttpRequestAuthorizer.class);
+        HttpProvider.HttpResponse mockHttpResponse = mock(HttpProvider.HttpResponse.class);
+        expectedResponseObject = new FakeResponse("testAccessToken", "Bearer");
+        String responseString = serializer.objectToJson(expectedResponseObject);
+        InputStream inputStream = new ByteArrayInputStream(responseString.getBytes("UTF-8"));
+        Mockito.when(mockHttpResponse.getResponseBody()).thenReturn(inputStream);
+        Mockito.when(mockHttpResponse.getStatusCode()).thenReturn(200);
+        Mockito.when(mockHttpProvider.execute(mockHttpRequest)).thenReturn(mockHttpResponse);
+        Mockito.when(mockHttpProvider.getRequest(Mockito.any(HttpProvider.HttpRequestAuthorizer.class), anyString(), anyString(), anyString()))
+                .thenReturn(mockHttpRequest);
+    }
+
+    @Test
+    public void test_sendMessage2() {
+        Client client = Client.builder().withHttpProvider(mockHttpProvider).withSerializer(serializer).build();
+        FakeResponse actualResponse = client.sendMessage(mockHttpRequest, FakeResponse.class,
+                ErrorResponse.class, (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+        assertTrue(expectedResponseObject.getAccessToken().equals(actualResponse.getAccessToken()));
+        assertTrue(expectedResponseObject.getTokenType().equals(actualResponse.getTokenType()));
+    }
+
+    @Test(expected = AccessTokenException.class)
+    public void test_sendMessage2_error() throws UnsupportedEncodingException, IOException, HttpException {
+        HttpProvider.HttpResponse mockHttpResponse = mock(HttpProvider.HttpResponse.class);
+        ErrorResponse expectedErrorResponse = new ErrorResponse("testError", "testErrorDesc",
+                "testId", 401, 401100, "testErrorMsg");
+        String responseString = serializer.objectToJson(expectedErrorResponse);
+        InputStream inputStream = new ByteArrayInputStream(responseString.getBytes("UTF-8"));
+        Mockito.when(mockHttpResponse.getResponseBody()).thenReturn(inputStream);
+        Mockito.when(mockHttpResponse.getStatusCode()).thenReturn(401);
+        Mockito.when(mockHttpProvider.execute(mockHttpRequest)).thenReturn(mockHttpResponse);
+
+        Client client = Client.builder().withHttpProvider(mockHttpProvider).withSerializer(serializer).build();
+        client.sendMessage(mockHttpRequest, FakeResponse.class,
+                ErrorResponse.class, (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+    }
+
+    @Test(expected = ResponseParsingException.class)
+    public void test_sendMessage2_parsingError() throws IOException, HttpException {
+        HttpProvider.HttpResponse mockHttpResponse = mock(HttpProvider.HttpResponse.class);
+        InputStream inputStream = new ByteArrayInputStream("{accessToken:}".getBytes("UTF-8"));
+        Mockito.when(mockHttpResponse.getResponseBody()).thenReturn(inputStream);
+        Mockito.when(mockHttpProvider.execute(mockHttpRequest)).thenReturn(mockHttpResponse);
+
+        Client client = Client.builder().withHttpProvider(mockHttpProvider).withSerializer(serializer).build();
+        client.sendMessage(mockHttpRequest, FakeResponse.class,
+                ErrorResponse.class, (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+    }
+
+    @Test(expected = RequestExecutionException.class)
+    public void test_sendMessage2_requestExceutionException() throws IOException, HttpException {
+        Mockito.when(mockHttpProvider.execute(mockHttpRequest)).thenThrow(new HttpException("Http Exception"));
+
+        Client client = Client.builder().withHttpProvider(mockHttpProvider).withSerializer(serializer).build();
+        client.sendMessage(mockHttpRequest, FakeResponse.class,
+                ErrorResponse.class, (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+    }
+
+    @Test
+    public void test_sendMessage1() {
+        Client client = Client.builder().withHttpProvider(mockHttpProvider).withSerializer(serializer)
+                .withClientAuthorizer(mockHttpRequestAuthorizer).build();
+        FakeRequest fakeRequest = new FakeRequest("testClientId", "testScope", "testGrantType");
+        FakeResponse actualResponse = client.sendMessage("POST",
+                "http://test.com",
+                fakeRequest,
+                FakeResponse.class,
+                ErrorResponse.class,
+                (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+        assertTrue(expectedResponseObject.getAccessToken().equals(actualResponse.getAccessToken()));
+        assertTrue(expectedResponseObject.getTokenType().equals(actualResponse.getTokenType()));
+    }
+
+    @Test
+    public void test_sendMessage1_requestBodyNull() {
+        Client client = Client.builder().withHttpProvider(mockHttpProvider).withSerializer(serializer)
+                .withClientAuthorizer(mockHttpRequestAuthorizer).build();
+        FakeResponse actualResponse = client.sendMessage("POST",
+                "http://test.com",
+                null,
+                FakeResponse.class,
+                ErrorResponse.class,
+                (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+        assertTrue(expectedResponseObject.getAccessToken().equals(actualResponse.getAccessToken()));
+        assertTrue(expectedResponseObject.getTokenType().equals(actualResponse.getTokenType()));
+    }
+
+    @Test
+    public void test_nullSafeCloseThrowingUnchecked_null() {
+        Client.nullSafeCloseThrowingUnchecked(null);
+    }
+
+    @Test
+    public void test_nullSafeCloseThrowingUnchecked_noException() {
+        Closeable closeable = new Closeable() {
+
+            @Override
+            public void close() throws IOException {
+                // no exceptions thrown
+            }
+        };
+        Client.nullSafeCloseThrowingUnchecked(closeable);
+    }
+
+    @Test
+    public void test_nullSafeCloseThrowingUnchecked_withException() {
+        final String message = "test I/O trouble!";
+        Closeable closeable = new Closeable() {
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException(message);
+            }
+
+        };
+        try {
+            Client.nullSafeCloseThrowingUnchecked(closeable);
+            Assert.fail("should have thrown UncheckedIOException");
+        } catch (UncheckedIOException unchecked) {
+            IOException ioe = unchecked.getCause();
+            assertTrue("ioe was null", null != ioe);
+            String actualMessage = ioe.getMessage();
+            assertTrue("message was expected " + message + ", actual " + actualMessage,
+                    message.equals(actualMessage));
+        }
+    }
+
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/AbstractCredentialTezt.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/AbstractCredentialTezt.java
@@ -88,10 +88,10 @@ public abstract class AbstractCredentialTezt {
             Field field = OAuth1ClientCredentialsProvider.class.getDeclaredField("oauth1Signer");
             field.setAccessible(true);
             OAuth1Signer oauth1Signer = (OAuth1Signer) field.get(hereCredentialsProvider);
-            field = OAuth1Signer.class.getDeclaredField("accessKeyId");
+            field = OAuth1Signer.class.getDeclaredField("consumerKey");
             field.setAccessible(true);
             accessKeyId = (String) field.get(oauth1Signer);
-            field = OAuth1Signer.class.getDeclaredField("accessKeySecret");
+            field = OAuth1Signer.class.getDeclaredField("consumerSecret");
             field.setAccessible(true);
             accessKeySecret = (String) field.get(oauth1Signer);
         }

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
@@ -1,0 +1,57 @@
+
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * 
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ * 
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class FileAccessTokenResponseTest {
+
+    FileAccessTokenResponse response;
+    
+    @Test
+    public void test_expiresIn() {
+        String accessToken = "my-access-token";
+        String tokenType = null;
+        Long expiresIn = null;
+        String refreshToken = null;
+        String idToken = null;
+        int secondsFromNow = 45;
+        Long exp = (System.currentTimeMillis() / 1000L) + secondsFromNow;
+        
+        response = new FileAccessTokenResponse( accessToken, 
+                 tokenType,
+                 expiresIn,  refreshToken,  idToken,
+                 exp);
+        
+        String actualAccessToken = response.getAccessToken();
+        assertTrue("accessToken didn't match expected "+accessToken+", actual "+actualAccessToken,
+                accessToken.equals(actualAccessToken));
+        
+        int minExpiresIn = secondsFromNow - 5;
+        Long actualExpiresIn = response.getExpiresIn();
+        int maxExpiresIn = secondsFromNow + 5;
+        assertTrue("expected expiresIn between " + minExpiresIn + " and " + maxExpiresIn + ", but got " 
+                + actualExpiresIn, 
+                null != actualExpiresIn && minExpiresIn <= actualExpiresIn && actualExpiresIn <= maxExpiresIn);
+
+        Long actualExp = response.getExp();
+        assertTrue("expected exp " + exp + ", actual " + actualExp,
+                exp.equals(actualExp));
+    }
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccessTokenProviderIT.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccessTokenProviderIT.java
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Map.Entry;
+import java.util.Properties;
+
+import org.junit.Ignore;
+import org.junit.Test;
+
+import com.here.account.auth.OAuth1ClientCredentialsProvider;
+import com.here.account.auth.provider.FromHereCredentialsIniFile;
+import com.here.account.auth.provider.FromHereCredentialsIniStream;
+import com.here.account.auth.provider.FromDefaultHereCredentialsPropertiesFileExposer;
+
+/**
+ * @author kmccrack
+ */
+public class HereAccessTokenProviderIT {
+
+    @Test
+    public void test_builder_basic() throws IOException {
+        try (
+                HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder().build()
+        ) {
+            String accessToken = accessTokens.getAccessToken();
+            assertTrue("accessToken was null", null != accessToken);
+            assertTrue("accessToken was blank", accessToken.trim().length() > 0);
+        }
+    }
+    
+    @Test
+    public void test_builder_basic_multipleTokens() throws IOException {
+        do_builder_basic(10);
+    }
+    
+    protected void do_builder_basic(int numTokens) throws IOException {
+        try (
+                HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder().build()
+        ) {
+            for (int i = 0; i < numTokens; i++) {
+                String accessToken = accessTokens.getAccessToken();
+                assertTrue("accessToken was null", null != accessToken);
+                assertTrue("accessToken was blank", accessToken.trim().length() > 0);
+            }
+        }
+    }
+
+    
+    @Ignore // we don't yet return credentials.ini files from our APIs
+    @Test
+    public void test_builder_ini() throws IOException {
+
+        try (
+                HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder()
+                .setClientAuthorizationRequestProvider(new FromHereCredentialsIniFile())
+                .build()
+        ) {
+            String accessToken = accessTokens.getAccessToken();
+            assertTrue("accessToken was null", null != accessToken);
+            assertTrue("accessToken was blank", accessToken.trim().length() > 0);
+        }
+    }
+    
+    @Test
+    public void test_builder_iniStream() throws IOException {
+
+        try (
+                InputStream inputStream = getTestIniFromOther();
+                HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder()
+                .setClientAuthorizationRequestProvider(new FromHereCredentialsIniStream(inputStream))
+                .build()
+        ) {
+            String accessToken = accessTokens.getAccessToken();
+            assertTrue("accessToken was null", null != accessToken);
+            assertTrue("accessToken was blank", accessToken.trim().length() > 0);
+        }
+    }
+
+    /**
+     * Using the file ~/.here/credentials.properties, create some fake credentials.ini 
+     * content by prepending the default section in memory, returning an InputStream to it.
+     * 
+     * @return
+     * @throws IOException
+     */
+    protected InputStream getTestIniFromOther() throws IOException {
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            outputStream.write("[default]\n".getBytes(StandardCharsets.UTF_8));
+            File file = FromDefaultHereCredentialsPropertiesFileExposer.getDefaultHereCredentialsFile();
+            
+            // System properties first
+            String tokenEndpointUrl = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY);
+            String accessKeyId = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY);
+            String accessKeySecret = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY);
+            if (null != tokenEndpointUrl && null != accessKeyId && null != accessKeySecret) {
+                outputStream.write((OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY 
+                        + "=" + tokenEndpointUrl + "\n").getBytes(StandardCharsets.UTF_8));
+                outputStream.write((OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY 
+                        + "=" + accessKeyId + "\n").getBytes(StandardCharsets.UTF_8));
+                outputStream.write((OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY 
+                        + "=" + accessKeySecret + "\n").getBytes(StandardCharsets.UTF_8));
+            } else {
+                Properties properties = OAuth1ClientCredentialsProvider.getPropertiesFromFile(file);
+                for (Entry<Object, Object> property : properties.entrySet()) {
+                    Object name = property.getKey();
+                    Object value = property.getValue();
+                    String line = name + "=" + value + "\n";
+                    outputStream.write(line.getBytes(StandardCharsets.UTF_8));
+                }
+            }
+            outputStream.flush();
+            byte[] bytes = outputStream.toByteArray();
+            return new ByteArrayInputStream(bytes);
+        }
+    }
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/SignInWithClientCredentialsIT.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/SignInWithClientCredentialsIT.java
@@ -29,6 +29,7 @@ import org.junit.Test;
 import com.here.account.auth.OAuth1ClientCredentialsProvider;
 import com.here.account.auth.OAuth1Signer;
 import com.here.account.http.HttpProvider;
+import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
 import com.here.account.util.Clock;
 
@@ -96,7 +97,20 @@ public class SignInWithClientCredentialsIT extends AbstractCredentialTezt {
             public HttpRequestAuthorizer getClientAuthorizer() {
                 return oauth1Signer;
             }
+
+            @Override
+            public AccessTokenRequest getNewAccessTokenRequest() {
+                return new ClientCredentialsGrantRequest();
+            }
             
+            /**
+             * {@inheritDoc}
+             */
+            @Override
+            public HttpMethods getHttpMethod() {
+                return HttpMethods.POST;
+            }
+
         };
         
         this.signIn = HereAccount.getTokenEndpoint(

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,7 @@
 
         <!-- Declare versions for dependencies -->
         <apache.httpclient.version>4.5.2</apache.httpclient.version>
+        <ini4j.version>0.5.1</ini4j.version>
         <commons-codec.version>1.10</commons-codec.version>
         <jackson.version>2.8.1</jackson.version>
         <junit.version>4.11</junit.version>
@@ -104,6 +105,11 @@
 
     <dependencyManagement>
         <dependencies>
+            <dependency>
+                <groupId>org.ini4j</groupId>
+                <artifactId>ini4j</artifactId>
+                <version>${ini4j.version}</version>
+            </dependency>
             <dependency>
                 <groupId>commons-codec</groupId>
                 <artifactId>commons-codec</artifactId>


### PR DESCRIPTION
…for OLP.

The HereAccessTokenProvider and Builder provide one-liner Builder patterns for constructing
an object that makes Access Tokens available.  The Builder permits overrides as needed.
Add ClientAuthorizationProviderChain, and ClientAuthorizationRequestProviders getting
credentials from each of the following sources: System properties, ini file, and properties file.
The default provider chain uses those 3, in that order.
Add incubator RunAsIdAuthorizationProvider for OLP runtimes to obtain Access Tokens.

Co-authored-by: Iyengar <swetha.iyengar@here.com>