### PR TITLE
clock skews: add support for self-correcting clock skew problems on t…

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth1ClientCredentialsProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth1ClientCredentialsProvider.java
@@ -27,13 +27,16 @@ import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.oauth2.AccessTokenRequest;
 import com.here.account.oauth2.ClientCredentialsGrantRequest;
 import com.here.account.oauth2.ClientCredentialsProvider;
+import com.here.account.util.Clock;
+import com.here.account.util.SettableSystemClock;
 
 /**
  * A {@link ClientCredentialsProvider} that injects client credentials by signing
  * token requests with an OAuth1 signature.
  */
 public class OAuth1ClientCredentialsProvider implements ClientCredentialsProvider {
-    
+
+    private final Clock clock;
     private final String tokenEndpointUrl;
     private final OAuth1Signer oauth1Signer;
     
@@ -49,12 +52,30 @@ public class OAuth1ClientCredentialsProvider implements ClientCredentialsProvide
     public OAuth1ClientCredentialsProvider(String tokenEndpointUrl,
                                            String accessKeyId,
                                            String accessKeySecret) {
+        this(new SettableSystemClock(), tokenEndpointUrl, accessKeyId, accessKeySecret);
+    }
+
+    public OAuth1ClientCredentialsProvider(Clock clock,
+                                           String tokenEndpointUrl,
+                                           String accessKeyId,
+                                           String accessKeySecret
+                                           ) {
+        Objects.requireNonNull(clock, "clock is required");
         Objects.requireNonNull(tokenEndpointUrl, "tokenEndpointUrl is required");
         Objects.requireNonNull(accessKeyId, "accessKeyId is required");
         Objects.requireNonNull(accessKeySecret, "accessKeySecret is required");
-        
+
+        this.clock = clock;
         this.tokenEndpointUrl = tokenEndpointUrl;
-        this.oauth1Signer = new OAuth1Signer(accessKeyId, accessKeySecret);
+        this.oauth1Signer = new OAuth1Signer(clock, accessKeyId, accessKeySecret);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Clock getClock() {
+        return clock;
     }
 
     /**

--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
@@ -18,6 +18,7 @@ package com.here.account.auth;
 import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpProvider.HttpRequest;
 import com.here.account.util.Clock;
+import com.here.account.util.SettableSystemClock;
 import org.apache.commons.codec.binary.Base64;
 
 import java.util.List;
@@ -46,7 +47,7 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
     private static final int NONCE_LENGTH = 6;
     
     private final Clock clock;
-    
+
     /**
      * HERE client accessKeyId.  Becomes the value of oauth_consumer_key in the 
      * Authorization: OAuth header.
@@ -71,7 +72,7 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
      *      in the Authorization: OAuth header.
      */
     public OAuth1Signer(String accessKeyId, String accessKeySecret) {
-        this(Clock.SYSTEM, accessKeyId, accessKeySecret);
+        this(new SettableSystemClock(), accessKeyId, accessKeySecret);
     }
     
     /**
@@ -99,7 +100,7 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
      * @param signatureMethod the choice of signature algorithm to use.
      */
     public OAuth1Signer(String consumerKey, String consumerSecret, SignatureMethod signatureMethod) {
-        this(Clock.SYSTEM, consumerKey, consumerSecret, signatureMethod);
+        this(new SettableSystemClock(), consumerKey, consumerSecret, signatureMethod);
     }
     
     /**

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromSystemProperties.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromSystemProperties.java
@@ -22,24 +22,44 @@ import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
 import com.here.account.oauth2.ClientAuthorizationRequestProvider;
 import com.here.account.oauth2.ClientCredentialsProvider;
+import com.here.account.util.Clock;
+import com.here.account.util.SettableSystemClock;
 
 /**
  * A {@link ClientCredentialsProvider} that pulls credential values from the System Properties.
  */
 public class FromSystemProperties extends ClientCredentialsGrantRequestProvider
 implements ClientAuthorizationRequestProvider {
+    private final Clock clock;
+
     public FromSystemProperties() {
+        this(new SettableSystemClock());
+    }
+
+    public FromSystemProperties(Clock clock) {
+        this.clock = clock;
     }
 
     protected ClientCredentialsProvider getDelegate() {
         Properties properties = System.getProperties();
-        return getClientCredentialsProviderWithDefaultTokenEndpointUrl(properties);
+        return getClientCredentialsProviderWithDefaultTokenEndpointUrl(clock, properties);
     }
 
     private static final String DEFAULT_TOKEN_ENDPOINT_URL = "https://account.api.here.com/oauth2/token";
 
+    /**
+     * @deprecated use {@link #getClientCredentialsProviderWithDefaultTokenEndpointUrl(Clock, Properties)}
+     * @param properties the properties
+     * @return the ClientCredentialsProvider
+     */
+    @Deprecated
     static ClientCredentialsProvider getClientCredentialsProviderWithDefaultTokenEndpointUrl(Properties properties) {
+        return getClientCredentialsProviderWithDefaultTokenEndpointUrl(new SettableSystemClock(), properties);
+    }
+
+    static ClientCredentialsProvider getClientCredentialsProviderWithDefaultTokenEndpointUrl(Clock clock, Properties properties) {
         return new OAuth1ClientCredentialsProvider(
+                clock,
                 properties.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY, DEFAULT_TOKEN_ENDPOINT_URL),
                 properties.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY),
                 properties.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY)
@@ -68,6 +88,14 @@ implements ClientAuthorizationRequestProvider {
     @Override
     public HttpMethods getHttpMethod() {
         return HttpMethods.POST;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Clock getClock() {
+        return clock;
     }
 
 }

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/incubator/RunAsIdAuthorizationProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/incubator/RunAsIdAuthorizationProvider.java
@@ -23,6 +23,7 @@ import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
 import com.here.account.oauth2.AccessTokenRequest;
 import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.util.Clock;
 
 /**
  * An incubator class that may be removed in subsequent releases,
@@ -93,6 +94,15 @@ public class RunAsIdAuthorizationProvider implements ClientAuthorizationRequestP
     @Override
     public HttpMethods getHttpMethod() {
         return HttpMethods.GET;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public Clock getClock() {
+        // not sure
+        return null;
     }
     
 }

--- a/here-oauth-client/src/main/java/com/here/account/client/Client.java
+++ b/here-oauth-client/src/main/java/com/here/account/client/Client.java
@@ -155,17 +155,17 @@ public class Client {
             BiFunction<Integer, U, RuntimeException> newExceptionFunction) 
             throws RequestExecutionException, ResponseParsingException {
         // blocking
-        HttpProvider.HttpResponse apacheResponse = null;
+        HttpProvider.HttpResponse httpResponse = null;
         InputStream jsonInputStream = null;
 
         try {
-            apacheResponse = httpProvider.execute(httpRequest);
-            jsonInputStream = apacheResponse.getResponseBody();
+            httpResponse = httpProvider.execute(httpRequest);
+            jsonInputStream = httpResponse.getResponseBody();
         } catch (IOException | HttpException e) {
             throw new RequestExecutionException(e);
         }
 
-        int statusCode = apacheResponse.getStatusCode();
+        int statusCode = httpResponse.getStatusCode();
         try {
             if (200 == statusCode || 201 == statusCode || 204 == statusCode) {
                 try {

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
@@ -66,7 +66,7 @@ public interface HttpProvider extends Closeable {
          */
         void authorize(HttpRequest httpRequest, String method, String url, 
                 Map<String, List<String>> formParams);
-        
+
     }
     
     /**

--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -347,7 +347,6 @@ public class ApacheHttpClientProvider implements HttpProvider {
         }
     }
 
-
     @Override
     public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
         if (!(httpRequest instanceof ApacheHttpClientRequest)) {

--- a/here-oauth-client/src/main/java/com/here/account/http/java/JavaHttpProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/java/JavaHttpProvider.java
@@ -235,38 +235,38 @@ public class JavaHttpProvider implements HttpProvider {
     public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
         if (!(httpRequest instanceof JavaHttpRequest)) {
             throw new IllegalArgumentException("httpRequest is not of expected type; use "
-                    +getClass()+".getRequest(..) to get a request of the expected type");
+                    + getClass() + ".getRequest(..) to get a request of the expected type");
         }
         JavaHttpRequest javaHttpRequest = (JavaHttpRequest) httpRequest;
-                 
+
         HttpURLConnection connection = getHttpUrlConnection(javaHttpRequest.getUrl());
         connection.setDoOutput(true);
         connection.setRequestMethod(javaHttpRequest.getMethod());
 
         byte[] body = javaHttpRequest.getBody();
         if (null != body) {
-            connection.setRequestProperty(HttpConstants.CONTENT_TYPE_HEADER, 
+            connection.setRequestProperty(HttpConstants.CONTENT_TYPE_HEADER,
                     javaHttpRequest.getContentType());
-            connection.setRequestProperty(HttpConstants.CONTENT_LENGTH_HEADER, 
+            connection.setRequestProperty(HttpConstants.CONTENT_LENGTH_HEADER,
                     javaHttpRequest.getContentLength());
         }
-        
+
         String authorizationHeader = javaHttpRequest.getAuthorizationHeader();
         if (null != authorizationHeader) {
             connection.setRequestProperty(HttpConstants.AUTHORIZATION_HEADER, authorizationHeader);
         }
-                 
+
         // Write data
-        try (
-            OutputStream outputStream = connection.getOutputStream()
-        ) {
-            if (null != body) {
+        if (null != body) {
+            try (
+                    OutputStream outputStream = connection.getOutputStream()
+            ) {
                 outputStream.write(body);
+                outputStream.flush();
             }
-            outputStream.flush();
         }
                  
-            // Read response
+        // Read response
         int statusCode = connection.getResponseCode();
         
         long responseContentLength = getContentLength(connection);

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
@@ -17,6 +17,7 @@ package com.here.account.oauth2;
 
 import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider;
+import com.here.account.util.Clock;
 
 /**
  * A {@code ClientAuthorizationRequestProvider} identifies a token endpoint,
@@ -56,5 +57,12 @@ public interface ClientAuthorizationRequestProvider {
      * @return the HTTP Method
      */
     HttpMethods getHttpMethod();
+
+    /**
+     * Get the Clock implementation in use.
+     *
+     * @return the Clock in use.
+     */
+    Clock getClock();
     
 }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccount.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccount.java
@@ -21,13 +21,17 @@ import java.io.InputStream;
 import java.io.UncheckedIOException;
 import java.net.URL;
 import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
+import com.here.account.auth.NoAuthorizer;
+import com.here.account.auth.provider.ClientAuthorizationProviderChain;
 import com.here.account.client.Client;
+import com.here.account.http.HttpConstants;
 import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider;
-import com.here.account.util.JacksonSerializer;
-import com.here.account.util.RefreshableResponseProvider;
-import com.here.account.util.Serializer;
+import com.here.account.oauth2.bo.TimestampResponse;
+import com.here.account.util.*;
 
 /**
  * Static entry point to access HERE Account via the OAuth2.0 API.  This class
@@ -144,20 +148,71 @@ public class HereAccount {
      * automatically be injected with the given client credentials.
      * 
      * @param httpProvider the HTTP-layer provider implementation
-     * @param clientCredentialsProvider identifies the token endpoint URL and
+     * @param clientAuthorizationRequestProvider identifies the token endpoint URL and
      *     client credentials to be injected into requests
      * @return a {@code TokenEndpoint} representing access for the provided client
      */
     public static TokenEndpoint getTokenEndpoint(
             HttpProvider httpProvider,
-            ClientAuthorizationRequestProvider clientCredentialsProvider) {
-        return getTokenEndpoint(httpProvider, clientCredentialsProvider, new JacksonSerializer());
+            ClientAuthorizationRequestProvider clientAuthorizationRequestProvider) {
+        return getTokenEndpoint(
+                reuseClock(clientAuthorizationRequestProvider),
+                httpProvider, clientAuthorizationRequestProvider, new JacksonSerializer());
     }
-    
-    public static TokenEndpoint getTokenEndpoint(HttpProvider httpProvider,
+
+    /**
+     * If we can re-use the Clock, then corrections made by HereAccount will agree
+     * with the ones the clientAuthorizationRequestProvider/OAuth1Signer uses.
+     * Otherwise, if clientAuthorizationRequestProvider is null, or its clock is
+     * null, a SettableSystemClock is returned.
+     *
+     * @param clientAuthorizationRequestProvider the authorization provider
+     * @return the clock to use
+     */
+    private static Clock reuseClock(ClientAuthorizationRequestProvider clientAuthorizationRequestProvider) {
+        Clock clock = null;
+        if (null != clientAuthorizationRequestProvider) {
+            clock = clientAuthorizationRequestProvider.getClock();
+        }
+        if (null == clock) {
+            clock = new SettableSystemClock();
+        }
+        return clock;
+    }
+
+    public static TokenEndpoint getTokenEndpoint(
+                                                 HttpProvider httpProvider,
+                                                 ClientAuthorizationRequestProvider clientAuthorizationRequestProvider,
+                                                 Serializer serializer) {
+        return getTokenEndpoint(reuseClock(clientAuthorizationRequestProvider),
+                httpProvider, clientAuthorizationRequestProvider, serializer);
+    }
+
+
+    /**
+     * Get the ability to run various Token Endpoint API calls to the
+     * HERE Account Authorization Server.
+     * See OAuth2.0
+     * <a href="https://tools.ietf.org/html/rfc6749#section-4">Obtaining Authorization</a>.
+     *
+     * The returned {@code TokenEndpoint} exposes an abstraction to make calls
+     * against the OAuth2 token endpoint identified by the given client credentials
+     * provider.  In addition, all calls made against the returned endpoint will
+     * automatically be injected with the given client credentials.
+     *
+     * @param clock the clock implementation to use
+     * @param httpProvider the HTTP-layer provider implementation
+     * @param clientCredentialsProvider identifies the token endpoint URL and
+     *     client credentials to be injected into requests
+     * @param serializer the Serializer to use
+     * @return a {@code TokenEndpoint} representing access for the provided client
+     */
+    private static TokenEndpoint getTokenEndpoint(Clock clock,
+                                                 HttpProvider httpProvider,
             ClientAuthorizationRequestProvider clientCredentialsProvider,
             Serializer serializer) {
-        return new TokenEndpointImpl(httpProvider, clientCredentialsProvider, serializer);
+        return new TokenEndpointImpl(clock,
+                httpProvider, clientCredentialsProvider, serializer);
     }
     
     /**
@@ -166,8 +221,10 @@ public class HereAccount {
      * you will always get a current HERE Access Token, 
      * for the grant_type=client_credentials use case, for 
      * confidential clients.
-     * 
+     *
+     * @param clock the clock to use
      * @param tokenEndpoint the token endpoint to request tokens
+     * @param accessTokenRequestFactory the Supplier of AccessTokenRequests
      * @return the refreshable response provider presenting an always "fresh" client_credentials-based HERE Access Token.
      * @throws AccessTokenException if you had trouble authenticating your request to the authorization server, 
      *      or the authorization server rejected your request
@@ -175,9 +232,11 @@ public class HereAccount {
      * @throws ResponseParsingException if trouble parsing the response
      */
     private static RefreshableResponseProvider<AccessTokenResponse> getRefreshableClientTokenProvider(
-            TokenEndpoint tokenEndpoint, Supplier<AccessTokenRequest> accessTokenRequestFactory) 
+            Clock clock,
+            TokenEndpoint tokenEndpoint, Supplier<AccessTokenRequest> accessTokenRequestFactory)
             throws AccessTokenException, RequestExecutionException, ResponseParsingException {
         return new RefreshableResponseProvider<>(
+                clock,
                 null,
                 tokenEndpoint.requestToken(accessTokenRequestFactory.get()),
                 (AccessTokenResponse previous) -> {
@@ -186,19 +245,30 @@ public class HereAccount {
                     } catch (AccessTokenException | RequestExecutionException | ResponseParsingException e) {
                         throw new RuntimeException("trouble refresh: " + e, e);
                     }
-                });
+                },
+                RefreshableResponseProvider.getScheduledExecutorServiceSize1()
+        );
     }
     
     /**
      * Implementation of {@link TokenEndpoint}.
      */
     private static class TokenEndpointImpl implements TokenEndpoint {
+        private static final Logger LOGGER = Logger.getLogger(TokenEndpointImpl.class.getName());
+
+
         /**
          * @deprecated to be removed.
          */
         @Deprecated
         public static final String HTTP_METHOD_POST = "POST";
-        
+
+        private final boolean currentTimeMillisSettable;
+        private final Clock clock;
+        private final SettableClock settableClock;
+        private final String timestampUrl;
+        private final boolean requestTokenFromFile;
+
         private final Client client;
         private final HttpProvider httpProvider;
         private final HttpMethods httpMethod;
@@ -215,9 +285,13 @@ public class HereAccount {
          * and provides access token request objects
          * @param serializer used to serialize json To pojo and vice versa
          */
-        private TokenEndpointImpl(HttpProvider httpProvider, ClientAuthorizationRequestProvider clientAuthorizationProvider,
+        private TokenEndpointImpl(
+                Clock clock,
+                HttpProvider httpProvider,
+                ClientAuthorizationRequestProvider clientAuthorizationProvider,
                 Serializer serializer) {
             // these values are fixed once selected
+            this.clock = clock;
             this.url = clientAuthorizationProvider.getTokenEndpointUrl();
             this.clientAuthorizer = clientAuthorizationProvider.getClientAuthorizer();
             this.httpMethod = clientAuthorizationProvider.getHttpMethod();
@@ -229,6 +303,18 @@ public class HereAccount {
                     .build();
             this.httpProvider = httpProvider;
             this.serializer = serializer;
+
+            requestTokenFromFile = null != url && url.startsWith(FILE_URL_START);
+
+            if (currentTimeMillisSettable = clock instanceof SettableClock
+                    && null != url && url.endsWith(SLASH_TOKEN)) {
+                settableClock = (SettableClock) clock;
+                timestampUrl = url.substring(0, url.length() - SLASH_TOKEN.length()) + SLASH_TIMESTAMP;
+            } else {
+                settableClock = null;
+                timestampUrl = null;
+            }
+
         }
         
         protected AccessTokenResponse requestTokenFromFile() 
@@ -242,22 +328,19 @@ public class HereAccount {
         }
         
         private static final String FILE_URL_START = "file://";
-        
-        protected boolean isRequestTokenFromFile() {
-            return null != url && url.startsWith(FILE_URL_START);
-        }
-        
+
         @Override
         public AccessTokenResponse requestToken(AccessTokenRequest authorizationRequest) 
                 throws AccessTokenException, RequestExecutionException, ResponseParsingException {            
-            if (isRequestTokenFromFile()) {
+            if (requestTokenFromFile) {
                 return requestTokenFromFile();
             } else {
-                return requestTokenHttp(authorizationRequest);
+                return requestTokenHttp(authorizationRequest, 1);
             }
         }
         
-        protected AccessTokenResponse requestTokenHttp(AccessTokenRequest authorizationRequest) 
+        protected AccessTokenResponse requestTokenHttp(AccessTokenRequest authorizationRequest,
+                                                       int retryFixableErrorsCount)
                 throws AccessTokenException, RequestExecutionException, ResponseParsingException {            
             String method = httpMethod.getMethod();
             
@@ -265,18 +348,78 @@ public class HereAccount {
             // OAuth2.0 uses application/x-www-form-urlencoded
             httpRequest = httpProvider.getRequest(
                 clientAuthorizer, method, url, authorizationRequest.toFormParams());
-            
-            return client.sendMessage(httpRequest, AccessTokenResponse.class,
-                    ErrorResponse.class, (statusCode, errorResponse) -> {
-                        return new AccessTokenException(statusCode, errorResponse);                        
+
+            try {
+                return client.sendMessage(httpRequest, AccessTokenResponse.class,
+                        ErrorResponse.class, (statusCode, errorResponse) -> {
+                            return new AccessTokenException(statusCode, errorResponse);
+                        });
+            } catch (AccessTokenException e) {
+                return handleFixableErrors(authorizationRequest, retryFixableErrorsCount, e);
+            }
+        }
+
+        private static final int CLOCK_SKEW_STATUS_CODE = 401;
+        private static final int CLOCK_SKEW_ERROR_CODE = 401204;
+        private static final long CONVERT_SECONDS_TO_MILLISECONDS = 1000L;
+
+        private static final String SLASH_TOKEN = "/oauth2/token";
+        private static final String SLASH_TIMESTAMP = "/timestamp";
+        private final NoAuthorizer noAuthorizer = new NoAuthorizer();
+
+        protected boolean canFixClockSkew(int retryFixableErrorsCount,
+                                          AccessTokenException e) {
+            ErrorResponse errorResponse;
+            return currentTimeMillisSettable
+                    && retryFixableErrorsCount > 0
+                    && null != e && CLOCK_SKEW_STATUS_CODE == e.getStatusCode()
+                    && null != (errorResponse = e.getErrorResponse())
+                    && CLOCK_SKEW_ERROR_CODE == errorResponse.getErrorCode();
+        }
+
+        protected TimestampResponse getServerTimestamp() {
+            // we have a clock skew
+            String method = HttpConstants.HttpMethods.GET.getMethod();
+
+            HttpProvider.HttpRequest httpRequest;
+            httpRequest = httpProvider.getRequest(
+                    noAuthorizer, method, timestampUrl, (String) null);
+
+            TimestampResponse timestampResponse = client.sendMessage(httpRequest, TimestampResponse.class,
+                    ErrorResponse.class, (statusCode, errorResponse2) -> {
+                        return new AccessTokenException(statusCode, errorResponse2);
                     });
+
+            return timestampResponse;
+        }
+
+        protected AccessTokenResponse handleFixableErrors(AccessTokenRequest authorizationRequest,
+                                                          int retryFixableErrorsCount,
+                                                          AccessTokenException e) {
+            if (canFixClockSkew(retryFixableErrorsCount, e)) {
+                // correct the Clock
+                try {
+                    TimestampResponse timestampResponse = getServerTimestamp();
+                    long timestamp = timestampResponse.getTimestamp();
+                    settableClock.setCurrentTimeMillis(timestamp * CONVERT_SECONDS_TO_MILLISECONDS);
+                } catch (Exception e2) {
+                    // trouble correcting the clock
+                    LOGGER.warning(() -> "correcting clock skew, trouble getting timestamp: " + e2);
+                    throw e;
+                }
+
+                // retry
+                return requestTokenHttp(authorizationRequest, retryFixableErrorsCount - 1);
+
+            }
+            throw e;
         }
         
         //@Override
         public Fresh<AccessTokenResponse> requestAutoRefreshingToken(Supplier<AccessTokenRequest> requestSupplier) 
                 throws AccessTokenException, RequestExecutionException, ResponseParsingException {
             final RefreshableResponseProvider<AccessTokenResponse> refresher = 
-                    HereAccount.getRefreshableClientTokenProvider(this, requestSupplier);
+                    HereAccount.getRefreshableClientTokenProvider(clock, this, requestSupplier);
             return new Fresh<AccessTokenResponse>() {
 
                 /**

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/bo/TimestampResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/bo/TimestampResponse.java
@@ -1,0 +1,51 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2.bo;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class TimestampResponse {
+
+    /**
+     * timestamp.
+     * The current time in seconds, since January 1, 1970.
+     * This can be used when the client needs to know the correct time for any subsequent calls,
+     * for client signed requests, for example.
+     */
+    @JsonProperty("timestamp")
+    private final Long timestamp;
+
+    public TimestampResponse() {
+        this(null);
+    }
+
+    public TimestampResponse(Long timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    /**
+     * Gets the timestamp.
+     * The current time in seconds, since January 1, 1970.
+     * This can be used when the client needs to know the correct time for any subsequent calls,
+     * for client signed requests, for example.
+     *
+     * @return the timestamp.
+     */
+    public Long getTimestamp() {
+        return timestamp;
+    }
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/util/SettableClock.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/SettableClock.java
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.util;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+public interface SettableClock extends Clock {
+
+    /**
+     * Sets the milliseconds UTC since the epoch to the specified value.
+     *
+     * @param currentTimeMillis this clock's currentTimeMillis in UTC since the epoch.
+     */
+    void setCurrentTimeMillis(long currentTimeMillis);
+
+}

--- a/here-oauth-client/src/main/java/com/here/account/util/SettableSystemClock.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/SettableSystemClock.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.util;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+/**
+ * A SettableSystemClock starts off using the {@link Clock#SYSTEM},
+ * but any time you set a "corrected" value via {@link #setCurrentTimeMillis(long)},
+ * will record a correction and work off that value instead.
+ * This Clock assumes that once a currentTimeMilliseconds is
+ * passed in as the "correct" value, the {@link Clock#SYSTEM} Clock will
+ * continue to process at the correct or near-correct pace.
+ * If it doesn't, the currentTimeMilliseconds may need to be
+ * set again periodically to the correct value.
+ */
+public class SettableSystemClock implements SettableClock {
+
+    private long behindMillis;
+
+    public SettableSystemClock() {
+        this.behindMillis = 0L;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public long currentTimeMillis() {
+        return Clock.SYSTEM.currentTimeMillis() + behindMillis;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void schedule(ScheduledExecutorService scheduledExecutorService, Runnable runnable, long millisecondsInTheFutureToSchedule) {
+        Clock.SYSTEM.schedule(scheduledExecutorService, runnable, millisecondsInTheFutureToSchedule);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void setCurrentTimeMillis(long correctCurrentTimeMillis) {
+        // currentTimeMillis is an outside source
+        behindMillis = correctCurrentTimeMillis - Clock.SYSTEM.currentTimeMillis();
+    }
+
+}
+

--- a/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerExposer.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerExposer.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.auth;
+
+import java.lang.reflect.Field;
+
+public class OAuth1SignerExposer {
+
+    /**
+     * Using reflection, get the accessKeyId from the oAuth1Signer.
+     * For test purposes only, we break the abstraction barrier.
+     *
+     * @param oAuth1Signer the OAuth1Signer whose accessKeyId to get
+     * @return the accessKeyId
+     * @throws NoSuchFieldException if the field is no longer defined
+     * @throws IllegalAccessException if access to the field's value is not permitted
+     */
+    public static String getAccessKeyId(OAuth1Signer oAuth1Signer) throws NoSuchFieldException, IllegalAccessException {
+        return getStringField(oAuth1Signer,"consumerKey");
+    }
+
+    protected static String getStringField(OAuth1Signer oAuth1Signer, String fieldName) throws NoSuchFieldException, IllegalAccessException {
+        Field field = OAuth1Signer.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        return (String) field.get(oAuth1Signer);
+    }
+
+    /**
+     * Using reflection, get the accessKeySecret from the oAuth1Signer.
+     * For test purposes only, we break the abstraction barrier.
+     *
+     * @param oAuth1Signer the OAuth1Signer whose accessKeySecret to get
+     * @return the accessKeySecret
+     * @throws NoSuchFieldException if the field is no longer defined
+     * @throws IllegalAccessException if access to the field's value is not permitted
+     */
+    public static String getAccessKeySecret(OAuth1Signer oAuth1Signer) throws NoSuchFieldException, IllegalAccessException {
+        return getStringField(oAuth1Signer,"consumerSecret");
+
+    }
+}

--- a/here-oauth-client/src/test/java/com/here/account/http/java/JavaHttpProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/http/java/JavaHttpProviderTest.java
@@ -32,6 +32,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import com.here.account.auth.NoAuthorizer;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -252,15 +253,8 @@ public class JavaHttpProviderTest {
     
     @Test
     public void test_noAuthorizationHeader() throws IOException, HttpException {
-        httpRequestAuthorizer = new HttpRequestAuthorizer() {
+        httpRequestAuthorizer = new NoAuthorizer();
 
-            @Override
-            public void authorize(HttpRequest httpRequest, String method, String url,
-                    Map<String, List<String>> formParams) {
-                // intentionally don't add any authorization header for this test
-            }
-            
-        };
         doRequest();
     }
 

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/AbstractHereAccountProviderTezt.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/AbstractHereAccountProviderTezt.java
@@ -17,6 +17,7 @@ package com.here.account.oauth2;
 
 import static org.junit.Assert.assertTrue;
 
+import com.here.account.util.SettableSystemClock;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -50,7 +51,7 @@ public abstract class AbstractHereAccountProviderTezt extends AbstractCredential
             String error = errorResponse.getError();
             final String expectedError = "invalid_client";
             assertTrue("\"error\" in JSON error response body was expected "
-                    +expectedError+", actual "+error, 
+                    +expectedError+", actual "+error+", errorResponse="+errorResponse,
                     expectedError.equals(error));
         }
     }
@@ -61,7 +62,8 @@ public abstract class AbstractHereAccountProviderTezt extends AbstractCredential
         
         TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
                 httpProvider, 
-                new OAuth1ClientCredentialsProvider(url, accessKeyId, accessKeySecret));
+                new OAuth1ClientCredentialsProvider(new SettableSystemClock(),
+                        url, accessKeyId, accessKeySecret));
         
         AccessTokenResponse accessTokenResponse = tokenEndpoint.requestToken(new ClientCredentialsGrantRequest());
         assertTrue("accessTokenResponse was null", null != accessTokenResponse);

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccessTokenProviderIT.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccessTokenProviderIT.java
@@ -17,6 +17,7 @@ package com.here.account.oauth2;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
@@ -26,14 +27,20 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.concurrent.ScheduledExecutorService;
 
+import com.here.account.auth.OAuth1Signer;
+import com.here.account.auth.OAuth1SignerExposer;
+import com.here.account.auth.provider.*;
+import com.here.account.http.HttpProvider;
+import com.here.account.util.Clock;
+import com.here.account.util.SettableClock;
+import com.here.account.util.SettableSystemClock;
 import org.junit.Ignore;
 import org.junit.Test;
 
 import com.here.account.auth.OAuth1ClientCredentialsProvider;
-import com.here.account.auth.provider.FromHereCredentialsIniFile;
-import com.here.account.auth.provider.FromHereCredentialsIniStream;
-import com.here.account.auth.provider.FromDefaultHereCredentialsPropertiesFileExposer;
+import org.mockito.Mockito;
 
 /**
  * @author kmccrack
@@ -54,6 +61,61 @@ public class HereAccessTokenProviderIT {
             assertEquals("tokenType invalid", "bearer", accessTokenResponse.getTokenType());
         }
     }
+
+    private static final int ONE_HOUR_SKEW_MILLIS = 60 * 60 * 1000;
+
+    @Test
+    public void test_builder_clockskew_spy() throws IOException, NoSuchFieldException, IllegalAccessException {
+        SettableSystemClock clock = new SettableSystemClock();
+        ClientAuthorizationProviderChain provider = ClientAuthorizationProviderChain
+                .getNewDefaultClientCredentialsProviderChain(clock);
+        ClientAuthorizationRequestProvider mockProvider =  Mockito.spy(provider);
+
+        OAuth1Signer oAuth1Signer = (OAuth1Signer) provider.getClientAuthorizer();
+        String accessKeyId = OAuth1SignerExposer.getAccessKeyId(oAuth1Signer);
+        String accessKeySecret = OAuth1SignerExposer.getAccessKeySecret(oAuth1Signer);
+        clock.setCurrentTimeMillis(0L);
+        HttpProvider.HttpRequestAuthorizer myAuthorizer = new OAuth1Signer(clock, accessKeyId, accessKeySecret);
+        Mockito.doReturn(myAuthorizer).when(mockProvider).getClientAuthorizer();
+
+        try (
+                HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder()
+                        .setClientAuthorizationRequestProvider(mockProvider)
+                        .setAlwaysRequestNewToken(true)
+                        .build()
+        ) {
+            String accessToken = accessTokens.getAccessToken();
+            assertTrue("accessToken was null", null != accessToken);
+            assertTrue("accessToken was blank", accessToken.trim().length() > 0);
+
+            AccessTokenResponse accessTokenResponse = accessTokens.getAccessTokenResponse();
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            assertEquals("tokenType invalid", "bearer", accessTokenResponse.getTokenType());
+        }
+
+    }
+
+    @Test
+    public void test_builder_clockskew() throws IOException, NoSuchFieldException, IllegalAccessException {
+        try (
+                HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder()
+                        .setAlwaysRequestNewToken(true)
+                        .build()
+        ) {
+            for (int i = 0; i < 2; i++) {
+
+                String accessToken = accessTokens.getAccessToken();
+                assertTrue("accessToken was null", null != accessToken);
+                assertTrue("accessToken was blank", accessToken.trim().length() > 0);
+
+                AccessTokenResponse accessTokenResponse = accessTokens.getAccessTokenResponse();
+                assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+                assertEquals("tokenType invalid", "bearer", accessTokenResponse.getTokenType());
+            }
+        }
+
+    }
+
 
     @Test
     public void test_builder_basic_multipleTokens() throws IOException {
@@ -90,17 +152,21 @@ public class HereAccessTokenProviderIT {
     
     @Test
     public void test_builder_iniStream() throws IOException {
-
+        Clock clock = new SettableSystemClock();
         try (
                 InputStream inputStream = getTestIniFromOther();
                 HereAccessTokenProvider accessTokens = HereAccessTokenProvider.builder()
-                .setClientAuthorizationRequestProvider(new FromHereCredentialsIniStream(inputStream))
+                .setClientAuthorizationRequestProvider(new FromHereCredentialsIniStream(clock, inputStream))
                 .build()
         ) {
             String accessToken = accessTokens.getAccessToken();
             assertTrue("accessToken was null", null != accessToken);
             assertTrue("accessToken was blank", accessToken.trim().length() > 0);
         }
+    }
+
+    protected boolean notEmpty(String s) {
+        return null != s && s.length() > 0;
     }
 
     /**
@@ -119,7 +185,7 @@ public class HereAccessTokenProviderIT {
             String tokenEndpointUrl = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY);
             String accessKeyId = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY);
             String accessKeySecret = System.getProperty(OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_SECRET_PROPERTY);
-            if (null != tokenEndpointUrl && null != accessKeyId && null != accessKeySecret) {
+            if (notEmpty(tokenEndpointUrl) && notEmpty(accessKeyId) && notEmpty(accessKeySecret)) {
                 outputStream.write((OAuth1ClientCredentialsProvider.FromProperties.TOKEN_ENDPOINT_URL_PROPERTY 
                         + "=" + tokenEndpointUrl + "\n").getBytes(StandardCharsets.UTF_8));
                 outputStream.write((OAuth1ClientCredentialsProvider.FromProperties.ACCESS_KEY_ID_PROPERTY 
@@ -137,6 +203,7 @@ public class HereAccessTokenProviderIT {
             }
             outputStream.flush();
             byte[] bytes = outputStream.toByteArray();
+            System.out.println("configs:\n"+(new String(bytes, StandardCharsets.UTF_8))+"\n");
             return new ByteArrayInputStream(bytes);
         }
     }

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccessTokenProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccessTokenProviderTest.java
@@ -1,0 +1,181 @@
+/*
+ * Copyright (c) 2018 HERE Europe B.V.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.here.account.oauth2;
+
+import static org.junit.Assert.assertTrue;
+
+import com.here.account.auth.NoAuthorizer;
+import com.here.account.http.HttpConstants;
+import com.here.account.http.HttpException;
+import com.here.account.http.HttpProvider;
+import com.here.account.util.Clock;
+import com.here.account.util.JacksonSerializer;
+import com.here.account.util.JsonSerializer;
+import com.here.account.util.Serializer;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.UUID;
+
+public class HereAccessTokenProviderTest {
+
+    HttpProvider mockHttpProvider;
+    String expectedAccessToken;
+    ClientAuthorizationRequestProvider clientAuthorizationRequestProvider;
+
+    @Before
+    public void setUp() throws IOException, HttpException {
+        mockHttpProvider = Mockito.mock(HttpProvider.class);
+        HttpProvider.HttpResponse httpResponse = Mockito.mock(HttpProvider.HttpResponse.class);
+        expectedAccessToken = "ey789."+ UUID.randomUUID().toString()+".878";
+        String responseBody = HereAccountTest.getResponseBody(expectedAccessToken);
+        byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+        Mockito.when(httpResponse.getStatusCode()).thenReturn(200);
+        Mockito.when(httpResponse.getResponseBody()).thenReturn(new ByteArrayInputStream(bytes));
+        Mockito.when(mockHttpProvider.execute(Mockito.any(HttpProvider.HttpRequest.class))).thenReturn(httpResponse);
+
+        clientAuthorizationRequestProvider = new ClientAuthorizationRequestProvider() {
+            @Override
+            public String getTokenEndpointUrl() {
+                return "https://www.example.com/oauth2/token";
+            }
+
+            @Override
+            public HttpProvider.HttpRequestAuthorizer getClientAuthorizer() {
+                return new NoAuthorizer();
+            }
+
+            @Override
+            public AccessTokenRequest getNewAccessTokenRequest() {
+                return new ClientCredentialsGrantRequest();
+            }
+
+            @Override
+            public HttpConstants.HttpMethods getHttpMethod() {
+                return HttpConstants.HttpMethods.POST;
+            }
+
+            @Override
+            public Clock getClock() {
+                return Clock.SYSTEM;
+            }
+        };
+
+    }
+
+    @Test
+    public void test_HereAccessTokenProvider_getToken() throws IOException, HttpException {
+        try (
+            HereAccessTokenProvider hereAccessTokenProvider
+                    = HereAccessTokenProvider.builder()
+                    .setHttpProvider(mockHttpProvider)
+                    .setClientAuthorizationRequestProvider(clientAuthorizationRequestProvider)
+                    .build();
+        ) {
+            AccessTokenResponse accessTokenResponse = hereAccessTokenProvider.getAccessTokenResponse();
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            String accessToken = accessTokenResponse.getAccessToken();
+            assertTrue("expected accessToken " + expectedAccessToken + ", actual " + accessToken,
+                    expectedAccessToken.equals(accessToken));
+        }
+    }
+
+    @Test
+    public void test_HereAccessTokenProvider_alwaysRequest_getToken() throws IOException, HttpException {
+        try (
+                HereAccessTokenProvider hereAccessTokenProvider
+                        = HereAccessTokenProvider.builder()
+                        .setHttpProvider(mockHttpProvider)
+                        .setClientAuthorizationRequestProvider(clientAuthorizationRequestProvider)
+                        .setAlwaysRequestNewToken(true)
+                        .build();
+        ) {
+            AccessTokenResponse accessTokenResponse = hereAccessTokenProvider.getAccessTokenResponse();
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            String accessToken = accessTokenResponse.getAccessToken();
+            assertTrue("expected accessToken " + expectedAccessToken + ", actual " + accessToken,
+                    expectedAccessToken.equals(accessToken));
+        }
+    }
+
+    @Test
+    public void test_HereAccessTokenProvider_defaultClientAuthorizationRequestProvider() throws IOException, HttpException {
+        try (
+                HereAccessTokenProvider hereAccessTokenProvider
+                        = HereAccessTokenProvider.builder()
+                        .setHttpProvider(mockHttpProvider)
+                        .build();
+        ) {
+            AccessTokenResponse accessTokenResponse = hereAccessTokenProvider.getAccessTokenResponse();
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            String accessToken = accessTokenResponse.getAccessToken();
+            assertTrue("expected accessToken " + expectedAccessToken + ", actual " + accessToken,
+                    expectedAccessToken.equals(accessToken));
+        }
+    }
+
+    @Test
+    public void test_HereAccessTokenProvider_jsonSerializer() throws IOException, HttpException {
+        Serializer jsonSerializer = Mockito.mock(Serializer.class);
+        String tokenType = "bearer";
+        Long expiresIn = 123L;
+        String refreshToken = null;
+        String idToken = null;
+        AccessTokenResponse deserializedAccessTokenResponse = new AccessTokenResponse(
+                 expectedAccessToken,
+                 tokenType,
+                 expiresIn,  refreshToken,  idToken
+        );
+        Mockito.when(jsonSerializer.jsonToPojo(Mockito.any(InputStream.class), Mockito.any(Class.class)))
+                .thenReturn(deserializedAccessTokenResponse);
+
+        try (
+                HereAccessTokenProvider hereAccessTokenProvider
+                        = HereAccessTokenProvider.builder()
+                        .setHttpProvider(mockHttpProvider)
+                        .setSerializer(jsonSerializer)
+                        .build();
+        ) {
+            AccessTokenResponse accessTokenResponse = hereAccessTokenProvider.getAccessTokenResponse();
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            String accessToken = accessTokenResponse.getAccessToken();
+            assertTrue("expected accessToken " + expectedAccessToken + ", actual " + accessToken,
+                    expectedAccessToken.equals(accessToken));
+        }
+    }
+
+    @Test
+    public void test_HereAccessTokenProvider_defaultHttpProvider() throws IOException, HttpException {
+
+        try (
+                HereAccessTokenProvider hereAccessTokenProvider
+                        = HereAccessTokenProvider.builder()
+                        .setAlwaysRequestNewToken(true)
+                        .build();
+        ) {
+            // we can't actually rely on the real HttpProvider/route working in a unit test
+            // we could optionally launch our own mock service on localhost port, and connect to it
+        }
+    }
+
+
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccountTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/HereAccountTest.java
@@ -16,16 +16,22 @@
 package com.here.account.oauth2;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
-import java.io.ByteArrayInputStream;
-import java.io.Closeable;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.UncheckedIOException;
+import java.io.*;
+import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ScheduledExecutorService;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.here.account.http.HttpConstants;
+import com.here.account.identity.bo.IdentityTokenRequest;
+import com.here.account.util.Clock;
+import com.here.account.util.JacksonSerializer;
+import com.here.account.util.SettableSystemClock;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -243,6 +249,342 @@ public class HereAccountTest extends AbstractCredentialTezt {
         }
     }
 
+    @Test(expected = NullPointerException.class)
+    public void test_getTokenEndpoint_null_clientAuthorizationRequestProvider() {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+        HereAccount.getTokenEndpoint(mockHttpProvider, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void test_getTokenEndpoint_null_url() {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+        ClientAuthorizationRequestProvider mockClientAuthorizationRequestProvider =
+                Mockito.mock(ClientAuthorizationRequestProvider.class);
+        Mockito.doReturn(null)
+                .when(mockClientAuthorizationRequestProvider).getTokenEndpointUrl();
+        Mockito.doReturn(HttpConstants.HttpMethods.POST)
+                .when(mockClientAuthorizationRequestProvider).getHttpMethod();
+
+        TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(mockHttpProvider, mockClientAuthorizationRequestProvider);
+        assertTrue("tokenEndpoint was null", null != tokenEndpoint);
+
+        AccessTokenRequest accessTokenRequest = new IdentityTokenRequest();
+        // we will get an error as the apache http response is null.
+        tokenEndpoint.requestToken(accessTokenRequest);
+    }
+
+    @Test
+    public void test_handleFixableErrors_timestampResponseError() throws IOException, HttpException {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+
+        int statusCode = 401;
+        String error = "foo";
+        String errorDescription = "bar";
+        String errorId = "3";
+        Integer httpStatus = statusCode;
+        Integer errorCode = 401204;
+        String message = "none";
+        ErrorResponse errorResponse = new ErrorResponse(
+                error,
+                errorDescription,
+                errorId,
+                httpStatus,
+                errorCode,
+                message
+        );
+
+        AccessTokenException toBeThrown = new AccessTokenException( statusCode, errorResponse);
+
+        int timestampStatusCode = 404;
+        Integer timestampErrorCode = 40404;
+        HttpResponse timestampHttpResponse = Mockito.mock(HttpResponse.class);
+        String timestampResponseBody = "{\"errorCode\":" + timestampErrorCode + "}";
+        byte[] timestampBytes = timestampResponseBody.getBytes(StandardCharsets.UTF_8);
+
+        Mockito.doReturn(timestampStatusCode)
+                .when(timestampHttpResponse).getStatusCode();
+        Mockito.doReturn(((long) timestampBytes.length))
+                .when(timestampHttpResponse).getContentLength();
+        Mockito.doReturn(new ByteArrayInputStream(timestampBytes))
+                .when(timestampHttpResponse).getResponseBody();
+
+        /*ErrorResponse timestampErrorResponse = new ErrorResponse(
+                error,
+                errorDescription,
+                errorId,
+                timestampStatusCode,
+                timestampErrorCode,
+                message
+        );*/
+
+        Mockito.when(mockHttpProvider.execute(Mockito.any(HttpProvider.HttpRequest.class)))
+                .thenThrow(toBeThrown)
+                .thenReturn(timestampHttpResponse);
+
+        ClientAuthorizationRequestProvider mockClientAuthorizationRequestProvider =
+                Mockito.mock(ClientAuthorizationRequestProvider.class);
+        Mockito.doReturn("https://www.example.com/oauth2/token")
+                .when(mockClientAuthorizationRequestProvider).getTokenEndpointUrl();
+        Mockito.doReturn(HttpConstants.HttpMethods.POST)
+                .when(mockClientAuthorizationRequestProvider).getHttpMethod();
+
+
+        TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(mockHttpProvider, mockClientAuthorizationRequestProvider);
+        assertTrue("tokenEndpoint was null", null != tokenEndpoint);
+
+        AccessTokenRequest accessTokenRequest = new IdentityTokenRequest();
+        // we will get an error as the apache http response is null.
+        try {
+            tokenEndpoint.requestToken(accessTokenRequest);
+        } catch (AccessTokenException e) {
+            // we expect the error from the original AccessTokenRequest to propagate.
+            // the timestamp error is suppressed
+            verifyExpected(e, 401, 401204);
+        }
+
+        Mockito.verify(mockHttpProvider, Mockito.times(2))
+                .execute(Mockito.any(HttpProvider.HttpRequest.class));
+    }
+
+    protected void verifyExpected(AccessTokenException e, int expectedStatusCode, int expectedErrorCode) {
+        int statusCode2 = e.getStatusCode();
+        assertTrue("statusCode2 was expected " + expectedStatusCode + ", actual " + statusCode2,
+                expectedStatusCode == statusCode2);
+        ErrorResponse errorResponse2 = e.getErrorResponse();
+        assertTrue("errorResponse2 was null", null != errorResponse2);
+        int errorCode2 = errorResponse2.getErrorCode();
+        assertTrue("errorCode2 was expected " + expectedErrorCode + ", actual " + errorCode2,
+                expectedErrorCode == errorCode2);
+    }
+
+    @Test
+    public void test_handleFixableErrors_401204_twice() throws IOException, HttpException {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+
+        HttpResponse timestampHttpResponse = Mockito.mock(HttpResponse.class);
+        String timestampResponseBody = "{\"timestamp\":123}";
+        byte[] timestampBytes = timestampResponseBody.getBytes(StandardCharsets.UTF_8);
+
+        Mockito.doReturn(200)
+                .when(timestampHttpResponse).getStatusCode();
+        Mockito.doReturn(((long) timestampBytes.length))
+                .when(timestampHttpResponse).getContentLength();
+        Mockito.doReturn(new ByteArrayInputStream(timestampBytes))
+                .when(timestampHttpResponse).getResponseBody();
+
+
+        HttpResponse tokenHttpResponse = Mockito.mock(HttpResponse.class);
+        String expectedAccessToken = "abc."+UUID.randomUUID().toString()+".xyz";
+        String responseBody = getResponseBody(expectedAccessToken);
+        byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+
+        Mockito.doReturn(200)
+                .when(tokenHttpResponse).getStatusCode();
+        Mockito.doReturn(((long) bytes.length))
+                .when(tokenHttpResponse).getContentLength();
+        Mockito.doReturn(new ByteArrayInputStream(bytes))
+                .when(tokenHttpResponse).getResponseBody();
+
+        int statusCode = 401;
+        String error = "foo";
+        String errorDescription = "bar";
+        String errorId = "3";
+        Integer httpStatus = statusCode;
+        Integer errorCode = 401204;
+        String message = "none";
+        ErrorResponse errorResponse = new ErrorResponse(
+                error,
+                errorDescription,
+                errorId,
+                httpStatus,
+                errorCode,
+                message
+        );
+
+        AccessTokenException toBeThrown = new AccessTokenException( statusCode, errorResponse);
+
+        Mockito.when(mockHttpProvider.execute(Mockito.any(HttpProvider.HttpRequest.class)))
+                .thenThrow(toBeThrown)
+                .thenReturn(timestampHttpResponse)
+                .thenThrow(toBeThrown);
+
+        /*Mockito.doThrow(toBeThrown)
+                .when(mockHttpProvider).execute(Mockito.any(HttpProvider.HttpRequest.class));*/
+        /*Mockito.doReturn(httpResponse)
+                .when(mockHttpProvider).execute(Mockito.any(HttpProvider.HttpRequest.class));*/
+        ClientAuthorizationRequestProvider mockClientAuthorizationRequestProvider =
+                Mockito.mock(ClientAuthorizationRequestProvider.class);
+        Mockito.doReturn("https://www.example.com/oauth2/token")
+                .when(mockClientAuthorizationRequestProvider).getTokenEndpointUrl();
+        Mockito.doReturn(HttpConstants.HttpMethods.POST)
+                .when(mockClientAuthorizationRequestProvider).getHttpMethod();
+
+
+        TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(mockHttpProvider, mockClientAuthorizationRequestProvider);
+        assertTrue("tokenEndpoint was null", null != tokenEndpoint);
+
+        try {
+            AccessTokenRequest accessTokenRequest = new IdentityTokenRequest();
+            tokenEndpoint.requestToken(accessTokenRequest);
+            fail("expected exception");
+        } catch (AccessTokenException e) {
+            verifyExpected(e, 401, 401204);
+        }
+
+        Mockito.verify(mockHttpProvider, Mockito.times(3))
+                .execute(Mockito.any(HttpProvider.HttpRequest.class));
+    }
+
+
+    @Test
+    public void test_handleFixableErrors() throws IOException, HttpException {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+
+        HttpResponse timestampHttpResponse = Mockito.mock(HttpResponse.class);
+        String timestampResponseBody = "{\"timestamp\":123}";
+        byte[] timestampBytes = timestampResponseBody.getBytes(StandardCharsets.UTF_8);
+
+        Mockito.doReturn(200)
+                .when(timestampHttpResponse).getStatusCode();
+        Mockito.doReturn(((long) timestampBytes.length))
+                .when(timestampHttpResponse).getContentLength();
+        Mockito.doReturn(new ByteArrayInputStream(timestampBytes))
+                .when(timestampHttpResponse).getResponseBody();
+
+
+        HttpResponse tokenHttpResponse = Mockito.mock(HttpResponse.class);
+        String expectedAccessToken = "abc."+UUID.randomUUID().toString()+".xyz";
+        String responseBody = getResponseBody(expectedAccessToken);
+        byte[] bytes = responseBody.getBytes(StandardCharsets.UTF_8);
+
+        Mockito.doReturn(200)
+                .when(tokenHttpResponse).getStatusCode();
+        Mockito.doReturn(((long) bytes.length))
+                .when(tokenHttpResponse).getContentLength();
+        Mockito.doReturn(new ByteArrayInputStream(bytes))
+                .when(tokenHttpResponse).getResponseBody();
+
+        int statusCode = 401;
+        String error = "foo";
+        String errorDescription = "bar";
+        String errorId = "3";
+        Integer httpStatus = statusCode;
+        Integer errorCode = 401204;
+        String message = "none";
+        ErrorResponse errorResponse = new ErrorResponse(
+                 error,
+                 errorDescription,
+                 errorId,
+                 httpStatus,
+                 errorCode,
+                 message
+        );
+
+        AccessTokenException toBeThrown = new AccessTokenException( statusCode, errorResponse);
+
+        Mockito.when(mockHttpProvider.execute(Mockito.any(HttpProvider.HttpRequest.class)))
+                .thenThrow(toBeThrown)
+                .thenReturn(timestampHttpResponse)
+                .thenReturn(tokenHttpResponse);
+
+        /*Mockito.doThrow(toBeThrown)
+                .when(mockHttpProvider).execute(Mockito.any(HttpProvider.HttpRequest.class));*/
+        /*Mockito.doReturn(httpResponse)
+                .when(mockHttpProvider).execute(Mockito.any(HttpProvider.HttpRequest.class));*/
+        ClientAuthorizationRequestProvider mockClientAuthorizationRequestProvider =
+                Mockito.mock(ClientAuthorizationRequestProvider.class);
+        Mockito.doReturn("https://www.example.com/oauth2/token")
+                .when(mockClientAuthorizationRequestProvider).getTokenEndpointUrl();
+        Mockito.doReturn(HttpConstants.HttpMethods.POST)
+                .when(mockClientAuthorizationRequestProvider).getHttpMethod();
+
+
+        TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(mockHttpProvider, mockClientAuthorizationRequestProvider);
+        assertTrue("tokenEndpoint was null", null != tokenEndpoint);
+
+        AccessTokenRequest accessTokenRequest = new IdentityTokenRequest();
+        // we will get an error as the apache http response is null.
+        AccessTokenResponse accessTokenResponse = tokenEndpoint.requestToken(accessTokenRequest);
+        assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+        String accessToken = accessTokenResponse.getAccessToken();
+        assertTrue("expected accessToken " + expectedAccessToken + ", actual " + accessToken,
+                expectedAccessToken.equals(accessToken));
+
+        Mockito.verify(mockHttpProvider, Mockito.times(3))
+                .execute(Mockito.any(HttpProvider.HttpRequest.class));
+    }
+
+
+    @Test
+    public void test_requestTokenFromFile() throws IOException {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+        ClientAuthorizationRequestProvider mockClientAuthorizationRequestProvider =
+                Mockito.mock(ClientAuthorizationRequestProvider.class);
+
+        //  Mockito.doReturn(myAuthorizer).when(mockProvider).getClientAuthorizer();
+
+        File file = File.createTempFile(UUID.randomUUID().toString(), ".tmp");
+        try {
+            final String expectedAccessToken = "ey23.45";
+            writeToFile(file, getResponseBody(expectedAccessToken));
+
+            Mockito.doReturn("file://" + file.getAbsolutePath())
+                    .when(mockClientAuthorizationRequestProvider).getTokenEndpointUrl();
+
+            TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(mockHttpProvider,
+                    mockClientAuthorizationRequestProvider);
+
+            AccessTokenResponse accessTokenResponse = tokenEndpoint.requestToken(new IdentityTokenRequest());
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            String accessToken = accessTokenResponse.getAccessToken();
+            assertTrue("expected access token " + expectedAccessToken + ", actual " + accessToken,
+                    expectedAccessToken.equals(accessToken));
+        } finally {
+            file.delete();
+        }
+
+    }
+
+    protected static String getResponseBody(String expectedAccessToken) {
+        return "{\"access_token\":\""+expectedAccessToken+"\",\"expires_in\":54321}";
+    }
+
+    @Test(expected = RequestExecutionException.class)
+    public void test_requestTokenFromFile_ioTrouble() throws IOException {
+        HttpProvider mockHttpProvider = Mockito.mock(HttpProvider.class);
+        ClientAuthorizationRequestProvider mockClientAuthorizationRequestProvider =
+                Mockito.mock(ClientAuthorizationRequestProvider.class);
+
+        //  Mockito.doReturn(myAuthorizer).when(mockProvider).getClientAuthorizer();
+
+        File file = File.createTempFile(UUID.randomUUID().toString(), ".tmp");
+        try {
+            final String expectedAccessToken = "ey23.45";
+            writeToFile(file, "{\"access_token\":\""+expectedAccessToken+"\"}");
+
+            Mockito.doReturn("file://" + file.getAbsolutePath())
+                    .when(mockClientAuthorizationRequestProvider).getTokenEndpointUrl();
+
+            TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(mockHttpProvider,
+                    mockClientAuthorizationRequestProvider);
+
+            file.delete();
+
+            tokenEndpoint.requestToken(new IdentityTokenRequest());
+        } finally {
+            file.delete();
+        }
+
+    }
+
+
+    private void writeToFile(File file, String content) throws IOException {
+        try (OutputStream outputStream = new FileOutputStream(file)) {
+            outputStream.write(content.getBytes(StandardCharsets.UTF_8));
+            outputStream.flush();
+        }
+    }
+
     @Test
     public void testGetFreshTokenVerifyRefresh() throws Exception {
         // first token expires after 30 seconds (minimum refresh time)
@@ -254,15 +596,26 @@ public class HereAccountTest extends AbstractCredentialTezt {
                 + " \"access_token\": \"67890\","
                 + " \"expires_in\": 30"
                 + "}";
+        final long sleepTimeMillis = 800L;
+            Clock mySettableClock = new SettableSystemClock() {
+                @Override
+                public void schedule(ScheduledExecutorService scheduledExecutorService,
+                                                 Runnable runnable,
+                                                 long millisecondsInTheFutureToSchedule
+                ) {
+                    super.schedule(scheduledExecutorService, runnable, sleepTimeMillis);
+                }
+            };
         
-        TokenEndpoint tokenEndpoint = HereAccount.getTokenEndpoint(
-                mockHttpProvider(dummyResponse(200, 
+        TokenEndpoint tokenEndpoint = (TokenEndpoint) HereAccount.getTokenEndpoint(
+                mockHttpProvider(dummyResponse(200,
                                                validToken1.getBytes().length, 
                                                new ByteArrayInputStream(validToken1.getBytes("UTF-8"))),
                                  dummyResponse(200,
                                                validToken2.getBytes().length,
                                                new ByteArrayInputStream(validToken2.getBytes("UTF-8")))),
-                new OAuth1ClientCredentialsProvider(url, accessKeyId, accessKeySecret));
+                new OAuth1ClientCredentialsProvider(mySettableClock, url, accessKeyId, accessKeySecret),
+                new JacksonSerializer());
         
         Fresh<AccessTokenResponse> freshToken = tokenEndpoint.
                 requestAutoRefreshingToken(new ClientCredentialsGrantRequest());
@@ -270,7 +623,7 @@ public class HereAccountTest extends AbstractCredentialTezt {
         Assert.assertEquals("12345", freshToken.get().getAccessToken());
         Assert.assertEquals("12345", freshToken.get().getAccessToken());
         // wait for refresh
-        Thread.sleep(31000);
+        Thread.sleep(sleepTimeMillis + 100L);
         // verify validToken2
         Assert.assertEquals("67890", freshToken.get().getAccessToken());
     }

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/SignInWithClientCredentialsIT.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/SignInWithClientCredentialsIT.java
@@ -111,6 +111,11 @@ public class SignInWithClientCredentialsIT extends AbstractCredentialTezt {
                 return HttpMethods.POST;
             }
 
+            @Override
+            public Clock getClock() {
+                return null;
+            }
+
         };
         
         this.signIn = HereAccount.getTokenEndpoint(


### PR DESCRIPTION
…he client host, using the get timestamp API.

You cannot specify a separate clock than the one injected into the HereAccessTokenProvider's ClientAuthorizationProvider's clock.
Suppress exception encountered while attempting to set the clock to the server's timestamp, and throw the original exception.
Add test code coverage.