### PR TITLE
Use Java 8's Base64 encoder/decoder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 **/.project
 **/.settings
 .idea/*
+*.iml
 target
 /bin/
 pom.xml.versionsBackup

--- a/examples/here-oauth-client-example/pom.xml
+++ b/examples/here-oauth-client-example/pom.xml
@@ -87,10 +87,6 @@
             <version>${project.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/here-oauth-client-dist/src/main/resources/LICENSE
+++ b/here-oauth-client-dist/src/main/resources/LICENSE
@@ -207,28 +207,6 @@ Copyright (C) 2016 HERE Europe B.V. All rights reserved.
 
 This software contains open source components pursuant to the following licenses:
 
-=== commons-codec 1.10 ===
-
-Copyright 2002-2013 The Apache Software Foundation
-Copyright (C) 2002 Kevin Atkinson (kevina@gnu.org) for DoubleMetaphoneTest.java
-Copyright (c) 2008 Alexander Beider & Stephen P. Morse for the content of 
-package org.apache.commons.codec.language.bm
-
-Licensed to the Apache Software Foundation (ASF) under one or more
-contributor license agreements.  See the NOTICE file distributed with
-this work for additional information regarding copyright ownership.
-The ASF licenses this file to You under the Apache License, Version 2.0
-(the "License"); you may not use this file except in compliance with
-the License.  You may obtain a copy of the License at
-
-    http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-
 === commons-logging 1.2 ===
 
 Copyright 2003-2014 The Apache Software Foundation

--- a/here-oauth-client/pom.xml
+++ b/here-oauth-client/pom.xml
@@ -85,10 +85,6 @@
             <artifactId>ini4j</artifactId>
         </dependency>
         <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-        </dependency>
-        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
         </dependency>

--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
@@ -19,8 +19,8 @@ import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpProvider.HttpRequest;
 import com.here.account.util.Clock;
 import com.here.account.util.SettableSystemClock;
-import org.apache.commons.codec.binary.Base64;
 
+import java.util.Base64;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
@@ -164,7 +164,7 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
         // choose the first 6 chars from base64 alphabet
         byte[] bytes = new byte[NONCE_LENGTH]; 
         nextBytes(bytes);
-        String nonce = Base64.encodeBase64URLSafeString(bytes).substring(0, NONCE_LENGTH);
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes).substring(0, NONCE_LENGTH);
         String computedSignature = calculator.calculateSignature(method, url, timestamp, nonce, 
                 signatureMethod,
                 formParams,

--- a/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
@@ -16,7 +16,6 @@
 package com.here.account.auth;
 
 import com.here.account.util.OAuthConstants;
-import org.apache.commons.codec.binary.Base64;
 
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
@@ -28,10 +27,7 @@ import java.security.PublicKey;
 import java.security.Signature;
 import java.security.spec.PKCS8EncodedKeySpec;
 import java.security.spec.X509EncodedKeySpec;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static com.here.account.auth.SignatureMethod.ES512;
 
@@ -286,7 +282,7 @@ public class SignatureCalculator {
             Signature s = Signature.getInstance(algorithm);
             s.initSign(consumerSecretToEllipticCurvePrivateKey(key));
             s.update(bytesToSign);
-            return Base64.encodeBase64String(s.sign());
+            return Base64.getEncoder().encodeToString(s.sign());
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
@@ -307,7 +303,7 @@ public class SignatureCalculator {
             Mac mac = Mac.getInstance(algorithm);
             mac.init(signingKey);
             byte[] signedBytes = mac.doFinal(bytesToSign);
-            return Base64.encodeBase64String(signedBytes);
+            return Base64.getEncoder().encodeToString(signedBytes);
         } catch (Exception e) {
             throw new IllegalArgumentException(e);
         }
@@ -318,7 +314,7 @@ public class SignatureCalculator {
      */
     private static PrivateKey consumerSecretToEllipticCurvePrivateKey(String key) {
         try {
-            byte[] keyBytes = Base64.decodeBase64(key);
+            byte[] keyBytes = Base64.getDecoder().decode(key);
             PKCS8EncodedKeySpec privateSpec = new PKCS8EncodedKeySpec(keyBytes);
             KeyFactory kf = KeyFactory.getInstance("EC");
             return kf.generatePrivate(privateSpec);
@@ -353,12 +349,12 @@ public class SignatureCalculator {
     private static boolean verifyECDSASignature(String cipherText, String signature, String verificationKey, SignatureMethod signatureMethod) {
         try {
             //convert the verification key to EC public key
-            byte[] keyBytes = Base64.decodeBase64(verificationKey);
+            byte[] keyBytes = Base64.getDecoder().decode(verificationKey);
             X509EncodedKeySpec publicSpec = new X509EncodedKeySpec(keyBytes);
             KeyFactory kf = KeyFactory.getInstance(ELLIPTIC_CURVE_ALGORITHM);
             PublicKey pubKey = kf.generatePublic(publicSpec);
 
-            byte[] signatureBytes = Base64.decodeBase64(signature.getBytes(OAuthConstants.UTF_8_STRING));
+            byte[] signatureBytes = Base64.getDecoder().decode(signature.getBytes(OAuthConstants.UTF_8_STRING));
             Signature s = Signature.getInstance(signatureMethod.getAlgorithm());
             s.initVerify(pubKey);
             s.update(cipherText.getBytes(OAuthConstants.UTF_8_STRING));

--- a/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
@@ -22,11 +22,7 @@ import java.net.URLEncoder;
 import java.security.InvalidKeyException;
 import java.security.Key;
 import java.security.NoSuchAlgorithmException;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -34,7 +30,6 @@ import java.util.regex.Pattern;
 import javax.crypto.Mac;
 import javax.crypto.spec.SecretKeySpec;
 
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Before;
 import org.junit.Test;
 
@@ -189,7 +184,7 @@ public class OAuth1SignerTest {
                 0x04,
                 0x05
         };
-        String nonce = Base64.encodeBase64URLSafeString(nonceBytes).substring(0, nonceBytes.length);
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
         
         long oauth_timestamp = clockCurrentTimeMillis / 1000L; // oauth1 uses seconds
 
@@ -236,7 +231,7 @@ public class OAuth1SignerTest {
             Mac mac = Mac.getInstance(signatureMethod);
             mac.init(signingKey);
             byte[] signedBytes = mac.doFinal(bytesToSign);
-            return Base64.encodeBase64String(signedBytes);
+            return Base64.getEncoder().encodeToString(signedBytes);
 
          */
         byte[] keyBytes = keyString.getBytes("UTF-8");
@@ -248,7 +243,7 @@ public class OAuth1SignerTest {
         byte[] signatureBytes = mac.doFinal(baseString.getBytes("UTF-8"));
     
         // base64-encode the hmac
-        //return new Base64().encodeAsString(signatureBytes);
-        return Base64.encodeBase64String(signatureBytes);
+        //return new Base64.getEncoder().encodeToString(signatureBytes);
+        return Base64.getEncoder().encodeToString(signatureBytes);
     }
 }

--- a/here-oauth-client/src/test/java/com/here/account/auth/SignatureCalculatorTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/SignatureCalculatorTest.java
@@ -19,7 +19,6 @@ import com.ning.http.client.FluentStringsMap;
 import com.ning.http.client.oauth.ConsumerKey;
 import com.ning.http.client.oauth.OAuthSignatureCalculator;
 import com.ning.http.client.oauth.RequestToken;
-import org.apache.commons.codec.binary.Base64;
 import org.junit.Test;
 
 import java.security.*;
@@ -189,12 +188,12 @@ public class SignatureCalculatorTest {
         KeyPair pair = generateES512KeyPair();
 
         final byte[] keyBytes = pair.getPrivate().getEncoded();
-        String keyBase64 = Base64.encodeBase64String(keyBytes);
+        String keyBase64 = Base64.getEncoder().encodeToString(keyBytes);
 
         SignatureCalculator sc = new SignatureCalculator(consumerKey, keyBase64);
         String signature = sc.calculateSignature(method, baseURL, timestamp, nonce, SignatureMethod.ES512, null, null);
 
-        String publicKeyBase64 = Base64.encodeBase64String(pair.getPublic().getEncoded());
+        String publicKeyBase64 = Base64.getEncoder().encodeToString(pair.getPublic().getEncoded());
         assertTrue(SignatureCalculator.verifySignature(consumerKey, method, baseURLWithPort, timestamp, nonce, SignatureMethod.ES512, null, null, signature, publicKeyBase64));
     }
 
@@ -203,12 +202,12 @@ public class SignatureCalculatorTest {
         KeyPair pair = generateES512KeyPair();
 
         final byte[] keyBytes = pair.getPrivate().getEncoded();
-        String keyBase64 = Base64.encodeBase64String(keyBytes);
+        String keyBase64 = Base64.getEncoder().encodeToString(keyBytes);
 
         SignatureCalculator sc = new SignatureCalculator(consumerKey, keyBase64);
         String signature = sc.calculateSignature(method, baseURLWithPort, timestamp, nonce, SignatureMethod.ES512, params, params);
 
-        String publicKeyBase64 = Base64.encodeBase64String(pair.getPublic().getEncoded());
+        String publicKeyBase64 = Base64.getEncoder().encodeToString(pair.getPublic().getEncoded());
         boolean verified = SignatureCalculator.verifySignature(consumerKey, method, baseURLWithPort, timestamp, nonce, SignatureMethod.ES512, params, params, signature, publicKeyBase64);
         assertTrue(verified);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,6 @@
         <!-- Declare versions for dependencies -->
         <apache.httpclient.version>4.5.2</apache.httpclient.version>
         <ini4j.version>0.5.1</ini4j.version>
-        <commons-codec.version>1.10</commons-codec.version>
         <jackson.version>2.8.1</jackson.version>
         <junit.version>4.11</junit.version>
         <mockito.version>1.10.19</mockito.version>
@@ -109,11 +108,6 @@
                 <groupId>org.ini4j</groupId>
                 <artifactId>ini4j</artifactId>
                 <version>${ini4j.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>commons-codec</groupId>
-                <artifactId>commons-codec</artifactId>
-                <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
Hi there!

This PR removes dependency to commons-codec and any references to the `org.apache.commons.codec.binary.Base64` class. Instead, it uses the class `java.util.Base64` part of Java 8.

I wasn't able to run the tests (even for master) successfully. I need some guidance on that, if possible.

Thanks