### PR TITLE
FromRunAsIdFileProvider: verify the underlying File exists before ret…

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromRunAsIdFileProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromRunAsIdFileProvider.java
@@ -15,10 +15,12 @@
  */
 package com.here.account.auth.provider;
 
+import java.io.File;
 import java.util.List;
 import java.util.Map;
 
 import com.here.account.auth.provider.AbstractClientAuthorizationRequestProvider;
+import com.here.account.http.HttpConstants;
 import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider.HttpRequest;
@@ -84,8 +86,21 @@ public class FromRunAsIdFileProvider
     public AccessTokenRequest getNewAccessTokenRequest() {
         return getRequest();
     }
-    
+
+    protected void verifyFileIsReadable() {
+        String tokenUrl = getTokenEndpointUrl();
+        if (tokenUrl.startsWith(HttpConstants.FILE_URL_START)) {
+            File file = new File(tokenUrl.substring(HttpConstants.FILE_URL_START.length()));
+            if (file.exists() && file.canRead()) {
+                return;
+            }
+        }
+        throw new RequestProviderException("trouble FromRunAsIdFile " + tokenUrl + " isn't readable");
+    }
+
     protected HttpProvider.HttpRequestAuthorizer getAuthorizer() {
+        verifyFileIsReadable();
+
         return ((HttpRequest httpRequest, String method, String url,
                 Map<String, List<String>> formParams) -> {});
     }

--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/FromRunAsIdFileProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/FromRunAsIdFileProvider.java
@@ -16,6 +16,8 @@
 package com.here.account.auth.provider;
 
 import java.io.File;
+import java.net.URL;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 
@@ -88,14 +90,17 @@ public class FromRunAsIdFileProvider
     }
 
     protected void verifyFileIsReadable() {
-        String tokenUrl = getTokenEndpointUrl();
-        if (tokenUrl.startsWith(HttpConstants.FILE_URL_START)) {
-            File file = new File(tokenUrl.substring(HttpConstants.FILE_URL_START.length()));
+        try {
+            URL url = new URL(getTokenEndpointUrl());
+            File file = Paths.get(url.toURI()).toFile();
             if (file.exists() && file.canRead()) {
                 return;
             }
+            throw new RequestProviderException("trouble FromRunAsIdFile " + tokenUrl + " isn't readable");
+        } catch (Exception e) {
+            throw new RequestProviderException("unable to verify whether file is readable " + tokenUrl);
+
         }
-        throw new RequestProviderException("trouble FromRunAsIdFile " + tokenUrl + " isn't readable");
     }
 
     protected HttpProvider.HttpRequestAuthorizer getAuthorizer() {

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpConstants.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpConstants.java
@@ -27,7 +27,6 @@ public class HttpConstants {
      */
     private HttpConstants() {}
 
-    public static final String FILE_URL_START = "file://";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String CHARSET_STRING = "UTF-8";
     public static final Charset ENCODING_CHARSET = Charset.forName(CHARSET_STRING);

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpConstants.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpConstants.java
@@ -27,6 +27,7 @@ public class HttpConstants {
      */
     private HttpConstants() {}
 
+    public static final String FILE_URL_START = "file://";
     public static final String AUTHORIZATION_HEADER = "Authorization";
     public static final String CHARSET_STRING = "UTF-8";
     public static final Charset ENCODING_CHARSET = Charset.forName(CHARSET_STRING);

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
@@ -15,6 +15,7 @@
  */
 package com.here.account.oauth2;
 
+import com.here.account.auth.provider.RequestProviderException;
 import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.http.HttpProvider;
 import com.here.account.util.Clock;
@@ -40,6 +41,8 @@ public interface ClientAuthorizationRequestProvider {
      * to authorize access token requests.
      * 
      * @return the client authorizer
+     * @throws RequestProviderException if no suitable authorizer can be
+     *      gotten, due to missing configuration elements
      */
     HttpProvider.HttpRequestAuthorizer getClientAuthorizer();
     

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccount.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccount.java
@@ -304,7 +304,7 @@ public class HereAccount {
             this.httpProvider = httpProvider;
             this.serializer = serializer;
 
-            requestTokenFromFile = null != url && url.startsWith(HttpConstants.FILE_URL_START);
+            requestTokenFromFile = null != url && url.startsWith(FILE_URL_START);
 
             if (currentTimeMillisSettable = clock instanceof SettableClock
                     && null != url && url.endsWith(SLASH_TOKEN)) {
@@ -326,6 +326,8 @@ public class HereAccount {
                 throw new RequestExecutionException(e);
             }
         }
+
+        private static final String FILE_URL_START = "file://";
 
         @Override
         public AccessTokenResponse requestToken(AccessTokenRequest authorizationRequest) 

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccount.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccount.java
@@ -304,7 +304,7 @@ public class HereAccount {
             this.httpProvider = httpProvider;
             this.serializer = serializer;
 
-            requestTokenFromFile = null != url && url.startsWith(FILE_URL_START);
+            requestTokenFromFile = null != url && url.startsWith(HttpConstants.FILE_URL_START);
 
             if (currentTimeMillisSettable = clock instanceof SettableClock
                     && null != url && url.endsWith(SLASH_TOKEN)) {
@@ -326,8 +326,6 @@ public class HereAccount {
                 throw new RequestExecutionException(e);
             }
         }
-        
-        private static final String FILE_URL_START = "file://";
 
         @Override
         public AccessTokenResponse requestToken(AccessTokenRequest authorizationRequest) 

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/FromRunAsIdFileProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/FromRunAsIdFileProviderTest.java
@@ -17,20 +17,30 @@ package com.here.account.auth.provider;
 
 import static org.junit.Assert.assertTrue;
 
+import com.here.account.http.HttpConstants;
 import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpConstants.HttpMethods;
 import com.here.account.oauth2.AccessTokenRequest;
 import com.here.account.oauth2.ClientAuthorizationRequestProvider;
+import com.here.account.util.Clock;
+import com.here.account.util.SettableSystemClock;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestName;
 import org.mockito.Mockito;
 
+import java.io.File;
 import java.io.IOException;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 
 public class FromRunAsIdFileProviderTest {
+    @Rule
+    public TestName testName = new TestName();
 
-    final String expectedTokenEndpointUrl = "file:///dev/shm/identity/access-token";
+
+    String expectedTokenEndpointUrl = "file:///dev/shm/identity/access-token";
     final String expectedGrantType = "identity";
 
     @Test
@@ -46,10 +56,32 @@ public class FromRunAsIdFileProviderTest {
     FromRunAsIdFileProvider provider;
     
     @Test
-    public void test_IdentityAuthorizationFileProvider() {
-        provider = new FromRunAsIdFileProvider();
+    public void test_IdentityAuthorizationFileProvider() throws IOException {
+        File file = File.createTempFile(testName.getMethodName(), "");
+        file.deleteOnExit();
+        String tokenUrl = HttpConstants.FILE_URL_START + file.getAbsolutePath();
+        provider = new FromRunAsIdFileProvider(new SettableSystemClock(), tokenUrl);
+        this.expectedTokenEndpointUrl = tokenUrl;
         verifyExpected(provider);
     }
+
+    @Test
+    public void test_inchain() throws IOException {
+        Clock clock = new SettableSystemClock();
+        File file = new File(UUID.randomUUID().toString());
+        String tokenUrl = HttpConstants.FILE_URL_START + file.getAbsolutePath();
+        provider = new FromRunAsIdFileProvider(clock, tokenUrl);
+        File file2 = File.createTempFile(testName.getMethodName(), "");
+        file2.deleteOnExit();
+        String tokenUrl2 = HttpConstants.FILE_URL_START + file2.getAbsolutePath();
+        ClientAuthorizationRequestProvider provider2 = new FromRunAsIdFileProvider(clock, tokenUrl2);
+        ClientAuthorizationRequestProvider providerChain = new ClientAuthorizationProviderChain(provider, provider2);
+        this.expectedTokenEndpointUrl = tokenUrl2;
+        // expected will only match if the providerChain successfully passed over provider,
+        // because the File didn't exist, and the providerChain chose provider2
+        verifyExpected(providerChain);
+    }
+
 
 
     protected void verifyExpected(ClientAuthorizationRequestProvider clientCredentialsProvider) {

--- a/here-oauth-client/src/test/java/com/here/account/auth/provider/FromRunAsIdFileProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/provider/FromRunAsIdFileProviderTest.java
@@ -59,21 +59,23 @@ public class FromRunAsIdFileProviderTest {
     public void test_IdentityAuthorizationFileProvider() throws IOException {
         File file = File.createTempFile(testName.getMethodName(), "");
         file.deleteOnExit();
-        String tokenUrl = HttpConstants.FILE_URL_START + file.getAbsolutePath();
+        String tokenUrl = FILE_URL_START + file.getAbsolutePath();
         provider = new FromRunAsIdFileProvider(new SettableSystemClock(), tokenUrl);
         this.expectedTokenEndpointUrl = tokenUrl;
         verifyExpected(provider);
     }
 
+    static final String FILE_URL_START = "file://";
+
     @Test
     public void test_inchain() throws IOException {
         Clock clock = new SettableSystemClock();
         File file = new File(UUID.randomUUID().toString());
-        String tokenUrl = HttpConstants.FILE_URL_START + file.getAbsolutePath();
+        String tokenUrl = FILE_URL_START + file.getAbsolutePath();
         provider = new FromRunAsIdFileProvider(clock, tokenUrl);
         File file2 = File.createTempFile(testName.getMethodName(), "");
         file2.deleteOnExit();
-        String tokenUrl2 = HttpConstants.FILE_URL_START + file2.getAbsolutePath();
+        String tokenUrl2 = FILE_URL_START + file2.getAbsolutePath();
         ClientAuthorizationRequestProvider provider2 = new FromRunAsIdFileProvider(clock, tokenUrl2);
         ClientAuthorizationRequestProvider providerChain = new ClientAuthorizationProviderChain(provider, provider2);
         this.expectedTokenEndpointUrl = tokenUrl2;


### PR DESCRIPTION
…urning the Authorizer.

This will indicate to the Provider Chain to skip over this Provider, and move on to the next; or if the only or last Provider, will propagate the exception.