### PR TITLE
token refresh: start retrying new tokens 1 minute before token expira…

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/util/RefreshableResponseProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/RefreshableResponseProvider.java
@@ -56,12 +56,12 @@ public class RefreshableResponseProvider<T extends ExpiringResponse> {
   /**
    * number of seconds to remove from suggested token timeout
    */
-  static final long REFRESH_BACKOFF_SECONDS = 10;
+  static final long REFRESH_BACKOFF_SECONDS = 60;
   /**
    * number of seconds to wait before refreshing a response when the
    * attempt to refresh failed
    */
-  static final long RETRY_FAIL_SECONDS = 1;
+  static final long RETRY_FAIL_SECONDS = 5;
 
   private final ResponseRefresher<T> refreshResponseFunction;
   private final ScheduledExecutorService scheduledExecutorService;


### PR DESCRIPTION
…tion.

Retries on failing requests for refresh, happen after a 5 second sleep.
This allows a 1 hour token to start refreshing at 59 minutes; and a 24-hour token to start refreshing at 23 hours, 59 minutes.