### PR TITLE
Upgrade to jackson 2.9.7 to address a vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <!-- Declare versions for dependencies -->
         <apache.httpclient.version>4.5.2</apache.httpclient.version>
         <ini4j.version>0.5.1</ini4j.version>
-        <jackson.version>2.8.1</jackson.version>
+        <jackson.version>2.9.7</jackson.version>
         <junit.version>4.11</junit.version>
         <mockito.version>1.10.19</mockito.version>
         <ning.version>1.8.17</ning.version>


### PR DESCRIPTION
See https://nvd.nist.gov/vuln/detail/CVE-2017-7525.