### PR TITLE
Add .ort.yml to define example project and test scope

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,0 +1,12 @@
+excludes:
+  projects:
+  - path: "examples/here-oauth-client-example/pom.xml"
+    reason: "EXAMPLE_OF"
+    comment: "The project an example how to implement AAA SDK in a client."
+  scopes:
+  - name: "provided"
+    reason: "PROVIDED_BY"
+    comment: "These are dependencies provided by the JDK or container at runtime. They are not distributed in the context of this project."
+  - name: "test"
+    reason: "TEST_TOOL_OF"
+    comment: "These are dependencies used for testing. They are not distributed in the context of this project."


### PR DESCRIPTION
The .ort.yml file is a machine-readable defintion used by OSS Review Toolkit (igithub.com/heremaps/oss-review-toolkit) to define which code is not distributed