### PR TITLE
Remove the obsolete tag from the POM

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,6 @@
       <connection>scm:git:https://github.com/heremaps/here-aaa-java-sdk.git</connection>
       <developerConnection>scm:git:git@github.com:heremaps/here-aaa-java-sdk.git</developerConnection>
       <url>https://github.com/heremaps/here-aaa-java-sdk</url>
-      <tag>v0.4.12</tag>
     </scm>
 
     <modules>


### PR DESCRIPTION
If the tag is not maintained / automatically updated, it is better to
not specify it at all.