### PR TITLE
HereAccessTokenProvider: fix javadocs to link to using the updated de…

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/auth/provider/ClientAuthorizationProviderChain.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/provider/ClientAuthorizationProviderChain.java
@@ -59,6 +59,16 @@ public class ClientAuthorizationProviderChain implements ClientAuthorizationRequ
      * The exact sequence of providers is subject to change in future releases, as
      * new providers are added.
      *
+     * <p>
+     * Currently, the default ClientCredentialsProviderChain uses
+     * <ul>
+     *     <li>System properties</li>
+     *     <li>~/.here/credentials.ini file</li>
+     *     <li>~/.here/credentials.properties file</li>
+     *     <li>file:///dev/shm/identity/access-token file</li>
+     * </ul>
+     * </p>
+     *
      * @param clock the clock implementation to use
      * @return the ClientAuthorizationProviderChain with default implementations in preference order
      */

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccessTokenProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/HereAccessTokenProvider.java
@@ -96,11 +96,7 @@ public class HereAccessTokenProvider implements AccessTokenSupplier, Closeable, 
     
     /**
      * By default the Builder uses
-     * <ul>
-     *     <li>System properties</li>
-     *     <li>~/.here/credentials.ini file</li>
-     *     <li>~/.here/credentials.properties file</li>
-     * </ul> for credentials,
+     * {@link ClientAuthorizationProviderChain#getNewDefaultClientCredentialsProviderChain(Clock)} for credentials,
      * the ApacheHttpClientProvider,
      * and the "always fresh" Access Token.
      */


### PR DESCRIPTION
HereAccessTokenProvider: fix javadocs to link to using the updated default ClientCredentialsProviderChain