### PR TITLE
AccessTokenResponse: change startTimeMilliseconds to transient.

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenResponse.java
@@ -68,13 +68,13 @@ public class AccessTokenResponse implements ExpiringResponse, OlpHttpMessage {
      * The start time in milliseconds, for this object, at the time it was 
      * constructed.
      */
-    private final Long startTimeMilliseconds;
+    private transient final Long startTimeMilliseconds;
 
     @JsonProperty("id_token")
     private final String idToken;
 
     private transient String correlationId;
-  
+
     /**
      * Requested scope of the access token. Supported scope-types are openId or project.
      */

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
@@ -29,8 +29,15 @@ import java.nio.file.Paths;
 
 public class FileAccessTokenResponseTest {
 
-    FileAccessTokenResponse response;
-    
+    private FileAccessTokenResponse response;
+
+    private File tmpFile;
+    private Serializer serializer;
+
+    private long prevStartTimeMillis;
+    private long prevExp;
+    private long prevExpiresIn;
+
     @Test
     public void test_expiresIn() {
         String accessToken = "my-access-token";
@@ -142,10 +149,4 @@ public class FileAccessTokenResponseTest {
         }
     }
 
-    File tmpFile;
-    Serializer serializer;
-
-    long prevStartTimeMillis;
-    long prevExp;
-    long prevExpiresIn;
 }

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
@@ -18,7 +18,14 @@ package com.here.account.oauth2;
 
 import static org.junit.Assert.assertTrue;
 
+import com.here.account.util.JacksonSerializer;
+import com.here.account.util.Serializer;
 import org.junit.Test;
+
+import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 public class FileAccessTokenResponseTest {
 
@@ -59,4 +66,86 @@ public class FileAccessTokenResponseTest {
         assertTrue("expected scope " + expectedScope + ", actual " + actualScope,
                 expectedScope.equals(actualScope));
     }
+
+    /**
+     * Tests the timestamp and relative timings for a FileAccessTokenResponse,
+     * when read multiple times from the same previously-serialized file,
+     * over increasing clock time.
+     *
+     * @throws IOException if IO trouble
+     * @throws InterruptedException if interrupted during sleep
+     */
+    @Test
+    public void test_timings_sameFile_multipleReads() throws IOException, InterruptedException {
+        String accessToken = "my-access-token";
+        String tokenType = "bearer";
+        Long expiresIn = 45L;
+        String refreshToken = null;
+        String idToken = null;
+
+        Long exp = (System.currentTimeMillis() / 1000L) + expiresIn;
+        String expectedScope = null;
+
+        response = new FileAccessTokenResponse(accessToken,
+                tokenType,
+                expiresIn, refreshToken, idToken,
+                exp, expectedScope);
+
+        long startTimeMillis = response.getStartTimeMilliseconds();
+
+        tmpFile = File.createTempFile("access_token", ".json");
+        tmpFile.deleteOnExit();
+
+        serializer = new JacksonSerializer();
+        try (OutputStream outputStream = new FileOutputStream(tmpFile)) {
+            serializer.writeObjectToJson(outputStream, response);
+        }
+
+        prevStartTimeMillis = startTimeMillis;
+        prevExp = exp;
+        prevExpiresIn = expiresIn;
+        for (int i = 0; i < 3; i++) {
+            verifyTimings();
+        }
+    }
+
+    private void verifyTimings() throws InterruptedException, IOException {
+        Thread.sleep(1001L);
+        Path path = Paths.get(tmpFile.toURI());
+        try (
+                InputStream in = Files.newInputStream(path)) {
+            FileAccessTokenResponse fileAccessTokenResponse = serializer.jsonToPojo(
+                    in,
+                    FileAccessTokenResponse.class
+            );
+            long startTimeMillis2 = fileAccessTokenResponse.getStartTimeMilliseconds();
+            long exp2 = fileAccessTokenResponse.getExp();
+            long expiresIn2 = fileAccessTokenResponse.getExpiresIn();
+
+            long low = prevStartTimeMillis + 1000;
+            long high = prevStartTimeMillis + 3000;
+
+            assertTrue("startTimeMillis was expected more than " + prevStartTimeMillis
+                            + ", actual " + startTimeMillis2 + " didn't fall in range (" + low + ", " + high + ")",
+                    low < startTimeMillis2 && startTimeMillis2 < prevStartTimeMillis + 2000);
+            assertTrue("exp was expected " + prevExp + ", actual " + exp2,
+                    prevExp == exp2);
+             low = prevExpiresIn - 3;
+             high = prevExpiresIn;
+            assertTrue("expiresIn was expected less than " + prevExpiresIn
+                            + ", actual " + expiresIn2 + " didn't fall in range (" + low + ", " + high + ")",
+                    low < expiresIn2 && expiresIn2 < high);
+
+            prevStartTimeMillis = startTimeMillis2;
+            prevExp = exp2;
+            prevExpiresIn = expiresIn2;
+        }
+    }
+
+    File tmpFile;
+    Serializer serializer;
+
+    long prevStartTimeMillis;
+    long prevExp;
+    long prevExpiresIn;
 }


### PR DESCRIPTION
this will ensure that if startTimeMilliseconds is serialized/deserialized, the startTimeMilliseconds will be the System.currentTimeMillis().
Add test case that verifies FileAccessTokenResponse works correctly with an access token file written once, and read
multiple times, over time, with decreasing getExpiresIn().