### PR TITLE
backward-compatiblity: add back in default implementation to public interface, and old constructor in AccessTokenResponse

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/client/Client.java
+++ b/here-oauth-client/src/main/java/com/here/account/client/Client.java
@@ -272,6 +272,12 @@ public class Client {
         Map<String, List<String>> headers = response.getHeaders();
         List<String> responseTypes = headers.get(HttpConstants.CONTENT_TYPE);
 
+        if (null == responseTypes || responseTypes.isEmpty()) {
+            // the burden of proof is on the Server specifying a non-JSON Content-Type.
+            // if there was no Content-Type specified, we default to JSON.
+            return true;
+        }
+
         for (String aResponseType: responseTypes) {
             if (aResponseType.toLowerCase().trim().startsWith(LOWERCASE_CONTENT_TYPE_JSON)) {
                 return true;

--- a/here-oauth-client/src/main/java/com/here/account/client/Client.java
+++ b/here-oauth-client/src/main/java/com/here/account/client/Client.java
@@ -269,21 +269,28 @@ public class Client {
      * @return  true-the response-type is JSON, false-the response-type is not JSON
      */
     private boolean isResponseTypeJson(HttpProvider.HttpResponse response) {
-        Map<String, List<String>> headers = response.getHeaders();
-        List<String> responseTypes = headers.get(HttpConstants.CONTENT_TYPE);
+        try {
+            Map<String, List<String>> headers = response.getHeaders();
+            List<String> responseTypes = headers.get(HttpConstants.CONTENT_TYPE);
 
-        if (null == responseTypes || responseTypes.isEmpty()) {
-            // the burden of proof is on the Server specifying a non-JSON Content-Type.
-            // if there was no Content-Type specified, we default to JSON.
-            return true;
-        }
-
-        for (String aResponseType: responseTypes) {
-            if (aResponseType.toLowerCase().trim().startsWith(LOWERCASE_CONTENT_TYPE_JSON)) {
+            if (null == responseTypes || responseTypes.isEmpty()) {
+                // the burden of proof is on the Server specifying a non-JSON Content-Type.
+                // if there was no Content-Type specified, we default to JSON.
                 return true;
             }
+
+            for (String aResponseType : responseTypes) {
+                if (aResponseType.toLowerCase().trim().startsWith(LOWERCASE_CONTENT_TYPE_JSON)) {
+                    return true;
+                }
+            }
+            return false;
+        } catch (UnsupportedOperationException e) {
+            // the default getHeaders implementation for backward-compatibility will come here.
+            // there's no way to get the Content-Type in this case,
+            // so return true for these providers.
+            return true;
         }
-        return false;
     }
 
     /**
@@ -352,14 +359,20 @@ public class Client {
      * @return the X-Correlation-ID, if there was one, or null
      */
     private String getCorrelationId(HttpProvider.HttpResponse httpResponse) {
-        Map<String, List<String>> headers = null != httpResponse ? httpResponse.getHeaders() : null;
-        List<String> values = null != headers ? headers.get(OlpHttpMessage.X_CORRELATION_ID) : null;
-        if (null != values && values.size() > 0) {
-            String correlationId = values.get(0);
-            if (null != correlationId && LOGGER.isLoggable(Level.FINE)) {
-                LOGGER.fine(OlpHttpMessage.X_CORRELATION_ID + ": " + correlationId);
+        try {
+            Map<String, List<String>> headers = null != httpResponse ? httpResponse.getHeaders() : null;
+            List<String> values = null != headers ? headers.get(OlpHttpMessage.X_CORRELATION_ID) : null;
+            if (null != values && values.size() > 0) {
+                String correlationId = values.get(0);
+                if (null != correlationId && LOGGER.isLoggable(Level.FINE)) {
+                    LOGGER.fine(OlpHttpMessage.X_CORRELATION_ID + ": " + correlationId);
+                }
+                return correlationId;
             }
-            return correlationId;
+        } catch (UnsupportedOperationException e) {
+            // the default getHeaders implementation for backward-compatibility will come here.
+            // there's no way to get the correlation id in this case,
+            // so return null for these providers.
         }
         return null;
     }

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
@@ -114,14 +114,13 @@ public interface HttpProvider extends Closeable {
         InputStream getResponseBody() throws IOException;
 
         /**
-         * Returns all the headers from the response.
-         *
-         * @return returns a Map of headers,
-         *      or an empty map if the implementing class has not overridden the default behavior.
+         * Returns all the headers from the response
+         * @return returns a Map of headers if the method implementation returns the headers
+         *      or throws Unsupported Operation Exception if the method is not implemented
          */
 
         default Map<String, List<String>> getHeaders() {
-            return Collections.emptyMap();
+            throw new UnsupportedOperationException();
         }
         
     }

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
@@ -18,7 +18,6 @@ package com.here.account.http;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -115,7 +114,7 @@ public interface HttpProvider extends Closeable {
 
         /**
          * Returns all the headers from the response
-         * @return returns a Map of headers if the method implementation returns the headers
+         * @return returns a Map of headers if the method implementation returns the headers 
          *      or throws Unsupported Operation Exception if the method is not implemented
          */
 

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
@@ -18,6 +18,7 @@ package com.here.account.http;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
@@ -113,13 +114,15 @@ public interface HttpProvider extends Closeable {
         InputStream getResponseBody() throws IOException;
 
         /**
-         * Returns all the headers from the response
-         * @return returns a Map of headers if the method implementation returns the headers 
-         *      or throws Unsupported Operation Exception if the method is not implemented
+         * Returns all the headers from the response.
+         *
+         * @return returns a Map of headers,
+         *      or an empty map if the implementing class has not overridden the default behavior.
          */
 
         default Map<String, List<String>> getHeaders() {
-            throw new UnsupportedOperationException();
+            return Collections.emptyMap();
+            //throw new UnsupportedOperationException();
         }
         
     }

--- a/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/HttpProvider.java
@@ -122,7 +122,6 @@ public interface HttpProvider extends Closeable {
 
         default Map<String, List<String>> getHeaders() {
             return Collections.emptyMap();
-            //throw new UnsupportedOperationException();
         }
         
     }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/AccessTokenResponse.java
@@ -85,6 +85,12 @@ public class AccessTokenResponse implements ExpiringResponse, OlpHttpMessage {
         this(null, null, null, null, null, null);
     }
 
+    @Deprecated
+    public AccessTokenResponse(String accessToken, String tokenType, Long expiresIn,
+                               String refreshToken, String idToken) {
+        this(accessToken, tokenType, expiresIn, refreshToken, idToken, null);
+    }
+
     public AccessTokenResponse(String accessToken, String tokenType, Long expiresIn,
                                String refreshToken, String idToken, String scope) {
         this.accessToken = accessToken;

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ClientAuthorizationRequestProvider.java
@@ -73,5 +73,7 @@ public interface ClientAuthorizationRequestProvider {
      *
      * @return the scope
      */
-    String getScope();
+    default String getScope() {
+        return null;
+    }
 }

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/ErrorResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/ErrorResponse.java
@@ -17,6 +17,8 @@ package com.here.account.oauth2;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 /**
  * The POJO representation of an OAuth2.0 HERE authorization server error response.
  * See also the 
@@ -431,6 +433,36 @@ public class ErrorResponse {
      */
     public String getCorrelationId() {
         return correlationId;
+    }
+    
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ErrorResponse that = (ErrorResponse) o;
+        return Objects.equals(error, that.error) &&
+                Objects.equals(errorDescription, that.errorDescription) &&
+                Objects.equals(httpStatus, that.httpStatus) &&
+                Objects.equals(errorId, that.errorId) &&
+                Objects.equals(errorCode, that.errorCode) &&
+                Objects.equals(message, that.message) &&
+                Objects.equals(title, that.title) &&
+                Objects.equals(status, that.status) &&
+                Objects.equals(code, that.code) &&
+                Objects.equals(cause, that.cause) &&
+                Objects.equals(action, that.action) &&
+                Objects.equals(correlationId, that.correlationId);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public int hashCode() {
+        return Objects.hash(error, errorDescription, httpStatus, errorId, errorCode, message, title, status, code, cause, action, correlationId);
     }
 
     /**

--- a/here-oauth-client/src/main/java/com/here/account/oauth2/FileAccessTokenResponse.java
+++ b/here-oauth-client/src/main/java/com/here/account/oauth2/FileAccessTokenResponse.java
@@ -55,6 +55,35 @@ public class FileAccessTokenResponse extends AccessTokenResponse {
         this(null, null, null, null,  null, null, null);
     }
 
+    /**
+     * Please use {@link #FileAccessTokenResponse(String, String, Long, String, String, Long, String)}.
+     *
+     * @param accessToken the accessToken
+     * @param tokenType the tokenType, for example "bearer"
+     * @param expiresIn the expiresIn, in seconds to expiration
+     * @param refreshToken the refreshToken
+     * @param idToken the idToken
+     * @param exp the expiration time in UTC seconds
+     */
+    @Deprecated
+    public FileAccessTokenResponse(String accessToken,
+                                   String tokenType,
+                                   Long expiresIn, String refreshToken, String idToken,
+                                   Long exp) {
+        this(accessToken, tokenType, expiresIn, refreshToken, idToken, exp, null);
+    }
+
+    /**
+     * Construct a FileAccessTokenResponse with the specified values.
+     *
+     * @param accessToken the accessToken
+     * @param tokenType the tokenType, for example "bearer"
+     * @param expiresIn the expiresIn, in seconds to expiration
+     * @param refreshToken the refreshToken
+     * @param idToken the idToken
+     * @param exp the expiration time in UTC seconds
+     * @param scope the scope of the accessToken, if applicable
+     */
     public FileAccessTokenResponse(String accessToken,
             String tokenType,
             Long expiresIn, String refreshToken, String idToken,

--- a/here-oauth-client/src/test/java/com/here/account/client/Client2Test.java
+++ b/here-oauth-client/src/test/java/com/here/account/client/Client2Test.java
@@ -1,0 +1,208 @@
+package com.here.account.client;
+
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import com.here.account.http.HttpException;
+import com.here.account.http.HttpProvider;
+import com.here.account.oauth2.AccessTokenException;
+import com.here.account.oauth2.AccessTokenResponse;
+import com.here.account.oauth2.ErrorResponse;
+import com.here.account.oauth2.ResponseParsingException;
+import com.here.account.util.JacksonSerializer;
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class Client2Test {
+
+    private HttpProvider backwardCompatibleHttpProvider;
+    private Client client;
+    private HttpProvider.HttpResponse httpResponse;
+    private JacksonSerializer serializer;
+    private String accessToken;
+    private String bodyString;
+    private int statusCode;
+    private HttpProvider.HttpRequest httpRequest;
+
+    private void setUp200() {
+        accessToken = "value";
+        bodyString = "{\"access_token\":\"" + accessToken + "\"}";
+        statusCode = 200;
+
+        setupClient();
+    }
+
+    private void setUp403_fromProxy() {
+        accessToken = "value";
+        bodyString = "<html><head><title>Forbidden</title></head><body>403 Forbiddent</body></html>";
+        statusCode = 403;
+
+        setupClient();
+    }
+
+    private void setUpResponse() {
+        final byte[] bodyBytes = bodyString.getBytes(StandardCharsets.UTF_8);
+        final int contentLength = bodyBytes.length;
+
+        if (overrideHeaders) {
+            this.httpResponse = new HttpProvider.HttpResponse() {
+
+                @Override
+                public int getStatusCode() {
+                    return statusCode;
+                }
+
+                @Override
+                public long getContentLength() {
+                    return contentLength;
+                }
+
+                @Override
+                public InputStream getResponseBody() throws IOException {
+                    return new ByteArrayInputStream(bodyBytes);
+                }
+
+                @Override
+                public Map<String, List<String>> getHeaders() {
+                    Map<String, List<String>> headers = new HashMap<String, List<String>>();
+                    headers.put("Content-Type", Collections.singletonList("text/html"));
+                    return headers;
+                }
+            };
+
+        } else {
+            this.httpResponse = new HttpProvider.HttpResponse() {
+
+                @Override
+                public int getStatusCode() {
+                    return statusCode;
+                }
+
+                @Override
+                public long getContentLength() {
+                    return contentLength;
+                }
+
+                @Override
+                public InputStream getResponseBody() throws IOException {
+                    return new ByteArrayInputStream(bodyBytes);
+                }
+            };
+        }
+
+    }
+
+    private boolean overrideHeaders = false;
+
+    private void setUpProvider() {
+        backwardCompatibleHttpProvider = new HttpProvider() {
+
+            @Override
+            public void close() throws IOException {
+
+            }
+
+            @Override
+            public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url, String requestBodyJson) {
+                return null;
+            }
+
+            @Override
+            public HttpRequest getRequest(HttpRequestAuthorizer httpRequestAuthorizer, String method, String url, Map<String, List<String>> formParams) {
+                return null;
+            }
+
+            @Override
+            public HttpResponse execute(HttpRequest httpRequest) throws HttpException, IOException {
+                return httpResponse;
+            }
+        };
+
+    }
+
+    private void setupClient() {
+        setUpResponse();
+        setUpProvider();
+        serializer = new JacksonSerializer();
+
+        client = Client.builder()
+                // TODO: possibly add good defaults in the Client.Builder to avoid NullPointerExceptions
+                .withHttpProvider(backwardCompatibleHttpProvider)
+                .withSerializer(serializer)
+                .build();
+        httpRequest = new HttpProvider.HttpRequest() {
+
+            @Override
+            public void addAuthorizationHeader(String value) {
+                throw new UnsupportedOperationException();
+            }
+        };
+
+    }
+
+    @Test
+    public void test_client_httpResponse_backwardsCompatible() {
+        setUp200();
+        AccessTokenResponse accessTokenResponse = client.sendMessage(httpRequest, AccessTokenResponse.class, ErrorResponse.class,
+                (statusCode, errorResponse) -> {
+                    return new AccessTokenException(statusCode, errorResponse);
+                });
+        assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+        String actualAccessToken = accessTokenResponse.getAccessToken();
+        assertTrue("expected access_token " + accessToken + ", actual " + actualAccessToken,
+                accessToken.equals(actualAccessToken));
+    }
+
+    @Test
+    public void test_client_httpResponse_backwardsCompatible_403fromProxy_noContentType() {
+        // the server did not tell us it wasn't JSON, so we send it to our JSON serializer,
+        // and get back an appropriate ResponseParsingException.
+        setUp403_fromProxy();
+        try {
+            AccessTokenResponse accessTokenResponse = client.sendMessage(httpRequest, AccessTokenResponse.class, ErrorResponse.class,
+                    (statusCode, errorResponse) -> {
+                        return new AccessTokenException(statusCode, errorResponse);
+                    });
+            assertTrue("accessTokenResponse was null", null != accessTokenResponse);
+            String actualAccessToken = accessTokenResponse.getAccessToken();
+            assertTrue("expected access_token " + accessToken + ", actual " + actualAccessToken,
+                    accessToken.equals(actualAccessToken));
+        } catch (ResponseParsingException e) {
+            String message = e.getMessage();
+            String expectedContains = "<";
+            assertTrue("message " + message + " was expected to contain " + expectedContains + ", but didn't",
+                    null != message && message.contains(expectedContains));
+        }
+    }
+
+    @Test
+    public void test_client_httpResponse_backwardsCompatible_403fromProxy_withContentType() {
+        // the server told us it was Content-Type: text/html, which is unrecognized,
+        // so we should just throw an Exception containing first up to 1KB of body.
+        this.overrideHeaders = true;
+        setUp403_fromProxy();
+        try {
+            AccessTokenResponse accessTokenResponse = client.sendMessage(httpRequest, AccessTokenResponse.class, ErrorResponse.class,
+                    (statusCode, errorResponse) -> {
+                        return new AccessTokenException(statusCode, errorResponse);
+                    });
+            fail("test case should have thrown exception, but didn't");
+        } catch (AccessTokenException e) {
+            int actualStatusCode = e.getStatusCode();
+            assertTrue("statusCode was expected " + statusCode + ", actual " + actualStatusCode, statusCode == actualStatusCode);
+            String message = e.getMessage();
+            assertTrue("message " + message + " was expected to contain " + bodyString + ", but didn't",
+                    null != message && message.contains(bodyString));
+        }
+    }
+
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/http/HttpResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/http/HttpResponseTest.java
@@ -1,6 +1,6 @@
 package com.here.account.http;
 
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.junit.Test;
 
@@ -13,7 +13,7 @@ import java.util.Map;
 
 public class HttpResponseTest {
 
-    @Test
+    @Test(expected = UnsupportedOperationException.class)
     public void test_backwardcompatible_HttpResponse_getHeaders() {
         final String bodyString = "bodyString";
         final byte[] bodyBytes = bodyString.getBytes(StandardCharsets.UTF_8);
@@ -38,7 +38,6 @@ public class HttpResponseTest {
         };
 
         Map<String, List<String>> headers = httpResponse.getHeaders();
-        assertTrue("headers was null", null != headers);
-        assertTrue("headers was not empty", headers.isEmpty());
+        fail("should have thrown UnsupportedOperationException, but didn't");
     }
 }

--- a/here-oauth-client/src/test/java/com/here/account/http/HttpResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/http/HttpResponseTest.java
@@ -1,0 +1,44 @@
+package com.here.account.http;
+
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Map;
+
+public class HttpResponseTest {
+
+    @Test
+    public void test_backwardcompatible_HttpResponse_getHeaders() {
+        final String bodyString = "bodyString";
+        final byte[] bodyBytes = bodyString.getBytes(StandardCharsets.UTF_8);
+        final int statusCode = 123;
+        final int contentLength = bodyBytes.length;
+        HttpProvider.HttpResponse httpResponse = new HttpProvider.HttpResponse() {
+
+            @Override
+            public int getStatusCode() {
+                return statusCode;
+            }
+
+            @Override
+            public long getContentLength() {
+                return contentLength;
+            }
+
+            @Override
+            public InputStream getResponseBody() throws IOException {
+                return new ByteArrayInputStream(bodyBytes);
+            }
+        };
+
+        Map<String, List<String>> headers = httpResponse.getHeaders();
+        assertTrue("headers was null", null != headers);
+        assertTrue("headers was not empty", headers.isEmpty());
+    }
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/AccessTokenResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/AccessTokenResponseTest.java
@@ -15,6 +15,8 @@
  */
 package com.here.account.oauth2;
 
+import static org.junit.Assert.assertTrue;
+
 import com.here.account.auth.OAuth1Signer;
 import com.here.account.http.HttpConstants;
 import com.here.account.http.HttpException;
@@ -48,6 +50,40 @@ public class AccessTokenResponseTest extends AbstractCredentialTezt{
                 expectedTokenType, expectedExpiresIn, expectedRefreshToken, expectedIdToken, expectedScope);
 
         assertEquals(response.getIdToken(), expectedIdToken);
+    }
+
+    @Test
+    public void test_backwardscompatible_constructor() {
+        String accessToken = "accessToken";
+        String tokenType = "tokenType";
+        Long expiresIn = 3600L;
+        String refreshToken = null;
+        String idToken = null;
+        String expectedScope = null;
+
+        AccessTokenResponse accessTokenResponse = new AccessTokenResponse( accessToken,  tokenType,  expiresIn,
+                 refreshToken,  idToken);
+        String actualAccessToken = accessTokenResponse.getAccessToken();
+        assertTrue("expected accessToken " + accessToken + ", actual " + actualAccessToken,
+                accessToken.equals(actualAccessToken));
+        String actualTokenType = accessTokenResponse.getTokenType();
+        assertTrue("expected tokenType " + tokenType + ", actual " + actualTokenType,
+                tokenType.equals(actualTokenType));
+        long actualExpiresIn = accessTokenResponse.getExpiresIn();
+        assertTrue("expected expiresIn " + expiresIn + ", actual " + actualExpiresIn,
+                expiresIn.equals(actualExpiresIn));
+        String actualRefreshToken = accessTokenResponse.getRefreshToken();
+        assertTrue("expected refreshToken " + refreshToken + ", actual " + actualRefreshToken,
+                null == actualRefreshToken);
+        String actualIdToken = accessTokenResponse.getIdToken();
+        assertTrue("expected idToken " + idToken + ", actual " + actualIdToken,
+                null == actualIdToken);
+
+        String actualScope = accessTokenResponse.getScope();
+        assertTrue("expected scope " + expectedScope + ", actual " + actualScope,
+                null == actualScope);
+
+
     }
 
     @Test

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/ClientAuthorizationRequestProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/ClientAuthorizationRequestProviderTest.java
@@ -1,0 +1,68 @@
+package com.here.account.oauth2;
+
+import static org.junit.Assert.assertTrue;
+
+import com.here.account.http.HttpConstants;
+import com.here.account.http.HttpProvider;
+import com.here.account.util.Clock;
+import org.junit.Test;
+
+import java.util.List;
+import java.util.Map;
+
+public class ClientAuthorizationRequestProviderTest {
+
+    ClientAuthorizationRequestProvider myProvider;
+
+    @Test
+    public void test_backward_compatible_interface() {
+        // DO NOT add any new method implementations here!
+
+        this.myProvider = new ClientAuthorizationRequestProvider() {
+            @Override
+            public String getTokenEndpointUrl() {
+                return "tokenEndpointUrl";
+            }
+
+            @Override
+            public HttpProvider.HttpRequestAuthorizer getClientAuthorizer() {
+                return new HttpProvider.HttpRequestAuthorizer() {
+                    @Override
+                    public void authorize(HttpProvider.HttpRequest httpRequest, String method, String url, Map<String, List<String>> formParams) {
+                        // no-op
+                    }
+                };
+            }
+
+            @Override
+            public AccessTokenRequest getNewAccessTokenRequest() {
+                return new ClientCredentialsGrantRequest();
+            }
+
+            @Override
+            public HttpConstants.HttpMethods getHttpMethod() {
+                return HttpConstants.HttpMethods.POST;
+            }
+
+            @Override
+            public Clock getClock() {
+                return Clock.SYSTEM;
+            }
+        };
+
+        assertTrue("myProvider was null", null != myProvider);
+    }
+
+    @Test
+    public void test_backward_compatible_getScope() {
+        // DO NOT add any new method implementations here!
+
+        test_backward_compatible_interface();
+
+        String scope = myProvider.getScope();
+        assertTrue("scope was expected null", null == scope);
+    }
+
+
+
+}

--- a/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/oauth2/FileAccessTokenResponseTest.java
@@ -39,6 +39,43 @@ public class FileAccessTokenResponseTest {
     private long prevExpiresIn;
 
     @Test
+    public void test_backwardcompatible_6_arg_constructor_noscope() {
+        String accessToken = "accessToken";
+        String tokenType = "bearer";
+        Long expiresIn = 123L;
+        String refreshToken = "refreshToken";
+        String idToken = "idToken";
+        Long exp = expiresIn + (System.currentTimeMillis() / 1000L);
+
+        response = new FileAccessTokenResponse(accessToken, tokenType, expiresIn, refreshToken, idToken, exp);
+
+        String actualAccessToken = response.getAccessToken();
+        assertTrue("expected accessToken " + accessToken + ", actual " + actualAccessToken,
+                accessToken.equals(actualAccessToken));
+        String actualTokenType = response.getTokenType();
+        assertTrue("expected tokenType " + tokenType + ", actual " + actualTokenType,
+                tokenType.equals(actualTokenType));
+        Long actualExpiresIn = response.getExpiresIn();
+        long high = expiresIn;
+        long low = expiresIn - 5;
+        assertTrue("expected expiresIn " + expiresIn + ", actual " + actualExpiresIn,
+                low <= actualExpiresIn && actualExpiresIn <= high);
+        String actualRefreshToken = response.getRefreshToken();
+        assertTrue("expected refreshToken " + refreshToken + ", actual " + actualRefreshToken,
+                refreshToken.equals(actualRefreshToken));
+        String actualIdToken = response.getIdToken();
+        assertTrue("expected idToken " + idToken + ", actual " + actualIdToken,
+                idToken.equals(actualIdToken));
+        Long actualExp = response.getExp();
+        assertTrue("expected exp " +  exp + ", actual " + actualExp,
+                exp.equals(actualExp));
+        String actualScope = response.getScope();
+        assertTrue("expected scope null, actual " + actualScope,
+                null == actualScope);
+
+    }
+
+    @Test
     public void test_expiresIn() {
         String accessToken = "my-access-token";
         String tokenType = null;


### PR DESCRIPTION
for ClientAuthorizationRequestProvider, add in default implementation for new interface method getScope(), for backwards-compatibility.
for AccessTokenResponse, add back in 5-argument public constructor.
for HttpProvider.HttpResponse, change backward-compatible default implementation to return an empty Map, rather than throw UnsupportedOperationException, so that Client's changes to look at headers is compatible with HttpResponse implementing classes that have not overridden the non-required method getHeaders().
fix bug in Client that doesn't do a null-check on the Content-Type header values.