### PR TITLE
AAA-7795: add support for repeating the same header name, in ApacheHttpClientProvider

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/http/apache/ApacheHttpClientProvider.java
@@ -20,11 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
 
 import org.apache.http.Header;
@@ -232,11 +228,12 @@ public class ApacheHttpClientProvider implements HttpProvider {
             Header[] headers = apacheHttpResponse.getAllHeaders();
             Map<String, List<String>> ret = new HashMap<>();
             for (Header header: headers) {
-                if(ret.containsKey(header.getName())) {
+                if (ret.containsKey(header.getName())) {
                     ret.get(header.getName()).add(header.getValue());
-                }
-                else {
-                    ret.put(header.getName(), Arrays.asList(header.getValue()));
+                } else {
+                    List<String> values = new ArrayList<String>();
+                    values.add(header.getValue());
+                    ret.put(header.getName(), values);
                 }
             }
             return ret;

--- a/here-oauth-client/src/test/java/com/here/account/http/apache/ApacheHttpClientProviderTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/http/apache/ApacheHttpClientProviderTest.java
@@ -20,21 +20,22 @@ import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpProvider.HttpRequest;
 import com.here.account.http.HttpProvider.HttpRequestAuthorizer;
 import org.apache.http.Header;
+import org.apache.http.HeaderElement;
 import org.apache.http.HttpEntity;
+import org.apache.http.ParseException;
 import org.apache.http.client.methods.*;
 import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.protocol.HttpContext;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.HttpURLConnection;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import static org.junit.Assert.*;
 import static org.mockito.Matchers.any;
@@ -107,6 +108,66 @@ public class ApacheHttpClientProviderTest {
         assertNotNull("response body is null", response.getResponseBody());
         assertTrue("response content length is 0", 0<response.getContentLength());
         assertTrue("Content-Type Header should be present", response.getHeaders().get("Content-Type") != null);
+    }
+
+    private static class MyHeader implements Header {
+
+        private final String name;
+        private final String value;
+
+        public MyHeader(String name, String value) {
+            this.name = name;
+            this.value = value;
+        }
+
+        @Override
+        public String getName() {
+            return name;
+        }
+
+        @Override
+        public String getValue() {
+            return value;
+        }
+
+        @Override
+        public HeaderElement[] getElements() throws ParseException {
+            return new HeaderElement[0];
+        }
+    }
+
+    @Test
+    public void test_getHeaders() throws IOException, HttpException {
+        String requestBodyJson = "{\"foo\":\"bar\"}";
+        url = "http://example.com";
+
+        CloseableHttpClient closeableHttpClient = Mockito.mock(CloseableHttpClient.class);
+
+        CloseableHttpResponse closeableHttpResponse = Mockito.mock(CloseableHttpResponse.class);
+        Mockito.when(closeableHttpClient.execute(Mockito.any(HttpRequestBase.class), Mockito.any(HttpContext.class)))
+                .thenReturn(closeableHttpResponse);
+        List<Header> headersList = new ArrayList<Header>();
+        Header fooHeader = new MyHeader("foo", "bar");
+        headersList.add(fooHeader);
+        Header setCookie1Header = new MyHeader("Set-Cookie", "a=b");
+        headersList.add(setCookie1Header);
+        Header setCookie2Header = new MyHeader("Set-Cookie", "c=d");
+        headersList.add(setCookie2Header);
+        Header[] headers = headersList.toArray(new Header[headersList.size()]);
+        Mockito.when(closeableHttpResponse.getAllHeaders())
+                .thenReturn(headers);
+
+        httpProvider = ApacheHttpClientProvider.builder()
+                .setHttpClient(closeableHttpClient)
+                .build();
+        httpRequest = httpProvider.getRequest(httpRequestAuthorizer, "PUT", url, requestBodyJson);
+        HttpProvider.HttpResponse response = httpProvider.execute(httpRequest);
+        assertTrue("response is null", null != response);
+        Map<String, List<String>> headersMap = response.getHeaders();
+        assertTrue("headersMap was null", null != headersMap);
+        List<String> values = headersMap.get(fooHeader.getName());
+        assertTrue("values was expected to contain " + fooHeader.getValue() + ", but was " + values,
+                null != values && 1 == values.size() && fooHeader.getValue().equals(values.get(0)));
     }
 
     @Test


### PR DESCRIPTION
adds support for repeating the same header name, in ApacheHttpClientProvider's HttpResponse 
getHeaders() method.  unit test demonstrates a failing case when the response has 2 "Set-Cookie" header lines, indicating the Server wants to set 2 different Cookies in the client.