### PR TITLE
.ort.yml: Migrate from project to path excludes

### DIFF
--- a/.ort.yml
+++ b/.ort.yml
@@ -1,6 +1,6 @@
 excludes:
-  projects:
-  - path: "examples/here-oauth-client-example/pom.xml"
+  paths:
+  - pattern: "examples/here-oauth-client-example/pom.xml"
     reason: "EXAMPLE_OF"
     comment: "The project an example how to implement AAA SDK in a client."
   scopes:


### PR DESCRIPTION
As support for project excludes has been dropped.

Signed-off-by: Frank Viernau frank.viernau@here.com