### PR TITLE
#87 - Fix OAuth1 signature to use query parameters

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
@@ -280,12 +280,18 @@ public class SignatureCalculator {
     }
 
     /**
-     * Utility method to URL encode a given string. If there are any spaces the URLEncodes encodes it to "+"
-     * but we require it to be "%20".
+     * Utility method to URL encode a given string. If there are any
+     * spaces the URLEncodes encodes it to "+" but we require it to be
+     * "%20". Also the RFC5849 requires that the character '~' must
+     * not be encoded and character '*' has to be encoded since it's
+     * not one.
      */
     static String urlEncode(String s) {
         try {
-            return URLEncoder.encode(s, OAuthConstants.UTF_8_STRING).replaceAll("\\+", "%20");
+            return URLEncoder.encode(s, OAuthConstants.UTF_8_STRING)
+                    .replace("+", "%20")
+                    .replace("*", "%2A")
+                    .replace("%7E", "~");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException(e);
         }


### PR DESCRIPTION
Fixed the OAuth1 signature calculation by parsing URL Query parameters and passing those to the signature calculator.
Added tests to verify that different kind of query parameters can be parsed and that one OAuth1 Signature with GET using query parameters is correctly calculated.