### PR TITLE
Fixed OAuth1 to support query parameters and RFC-compliant encoding

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/OAuth1Signer.java
@@ -18,11 +18,16 @@ package com.here.account.auth;
 import com.here.account.http.HttpProvider;
 import com.here.account.http.HttpProvider.HttpRequest;
 import com.here.account.util.Clock;
+import com.here.account.util.OAuthConstants;
 import com.here.account.util.SettableSystemClock;
 
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
 import java.util.Base64;
 import java.util.List;
 import java.util.Map;
+import java.util.HashMap;
+import java.util.ArrayList;
 import java.util.concurrent.ThreadLocalRandom;
 
 /**
@@ -136,6 +141,39 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
     }
 
     /**
+     * Extract query parameters from a raw query string.
+     *
+     * @param the raw query string as a substring from the URL.
+     * @return map containing list of query parameters.
+     */
+    protected Map<String, List<String>> getQueryParams(String query) {
+        Map<String, List<String>> queryParams = new HashMap<>();
+        String[] kvPairs = query.split("&");
+        for (String kvPair : kvPairs) {
+            int ix = kvPair.indexOf("=");
+            String key = kvPair;
+            String value = "";
+            if (ix != -1) {
+                key = kvPair.substring(0, ix);
+                value = kvPair.substring(ix + 1);
+            }
+            try {
+                key = URLDecoder.decode(key, OAuthConstants.UTF_8_STRING);
+                value = URLDecoder.decode(value, OAuthConstants.UTF_8_STRING);
+            } catch (UnsupportedEncodingException e) {
+                throw new IllegalArgumentException(e);
+            }
+            List<String> values = queryParams.get(key);
+            if (values == null) {
+                values = new ArrayList<>();
+                queryParams.put(key, values);
+            }
+            values.add(value);
+        }
+        return queryParams;
+    }
+
+    /**
      * For cases where there is no Content-Type: application/x-www-form-urlencoded, 
      * and no request token, call this method to get the Authorization Header Value 
      * for a single request.  
@@ -165,15 +203,22 @@ public class OAuth1Signer implements HttpProvider.HttpRequestAuthorizer {
         byte[] bytes = new byte[NONCE_LENGTH]; 
         nextBytes(bytes);
         String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes).substring(0, NONCE_LENGTH);
+        int qPos = url.indexOf('?');
+        Map<String, List<String>> queryParams = null;
+        if (qPos != -1) {
+            String query = url.substring(qPos + 1);
+            queryParams = getQueryParams(query);
+            url = url.substring(0, qPos);
+        }
         String computedSignature = calculator.calculateSignature(method, url, timestamp, nonce, 
                 signatureMethod,
                 formParams,
-                null);
+                queryParams);
         
         return calculator.constructAuthHeader(computedSignature, nonce, timestamp, 
                 signatureMethod);
     }
-    
+
     /**
      * Gets the signature calculator, given that we don't use a user auth, and we do use 
      * the configured client accessKeyId, client accessKeySecret pair.

--- a/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
+++ b/here-oauth-client/src/main/java/com/here/account/auth/SignatureCalculator.java
@@ -63,7 +63,8 @@ public class SignatureCalculator {
      * but with oauthVersion hard-coded to "1.0".
      *
      * @param method          the HTTP method
-     * @param baseURL         the base url including the protocol, host and port.
+     * @param baseURL         The base url including the protocol, host, port, and path.
+     *                        The query portion of the request URL must be assembled in the 'queryParams' input.
      * @param oauthTimestamp  the time stamp
      * @param nonce           nonce
      * @param signatureMethod signature method to be used - supported are HMAC-SHA1, HMAC-SHA256, ES512
@@ -85,7 +86,8 @@ public class SignatureCalculator {
      * Calculate the OAuth 1.0 signature based on the given parameters
      *
      * @param method          the HTTP method
-     * @param baseURL         the base url including the protocol, host and port.
+     * @param baseURL         The base url including the protocol, host, port, and path.
+     *                        The query portion of the request URL must be assembled in the 'queryParams' input.
      * @param oauthTimestamp  the time stamp
      * @param nonce           nonce
      * @param signatureMethod signature method to be used - supported are HMAC-SHA1, HMAC-SHA256, ES512
@@ -137,7 +139,8 @@ public class SignatureCalculator {
      *
      * @param consumerKey     the consumer key
      * @param method          the HTTP method
-     * @param baseURL         the base url including the protocol, host and port.
+     * @param baseURL         The base url including the protocol, host, port, and path.
+     *                        The query portion of the request URL must be assembled in the 'queryParams' input.
      * @param oauthTimestamp  the time stamp
      * @param nonce           nonce
      * @param signatureMethod signature method to be used - supported are HMAC-SHA1, HMAC-SHA256, ES512
@@ -187,7 +190,8 @@ public class SignatureCalculator {
      *
      * @param consumerKey     the consumer key
      * @param method          the HTTP method
-     * @param baseURL         the base url including the protocol, host and port.
+     * @param baseURL         The base url including the protocol, host, port, and path.
+     *                        The query portion of the request URL must be assembled in the 'queryParams' input.
      * @param oauthTimestamp  the time stamp
      * @param nonce           nonce
      * @param signatureMethod signature method to be used - supported are HMAC-SHA1, HMAC-SHA256, ES512
@@ -280,12 +284,18 @@ public class SignatureCalculator {
     }
 
     /**
-     * Utility method to URL encode a given string. If there are any spaces the URLEncodes encodes it to "+"
-     * but we require it to be "%20".
+     * Utility method to URL encode a given string. If there are any
+     * spaces the URLEncodes encodes it to "+" but we require it to be
+     * "%20". Also the RFC5849 requires that the character '~' must
+     * not be encoded and character '*' has to be encoded since it's
+     * not one.
      */
     static String urlEncode(String s) {
         try {
-            return URLEncoder.encode(s, OAuthConstants.UTF_8_STRING).replaceAll("\\+", "%20");
+            return URLEncoder.encode(s, OAuthConstants.UTF_8_STRING)
+                    .replace("+", "%20")
+                    .replace("*", "%2A")
+                    .replace("%7E", "~");
         } catch (UnsupportedEncodingException e) {
             throw new IllegalArgumentException(e);
         }

--- a/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
+++ b/here-oauth-client/src/test/java/com/here/account/auth/OAuth1SignerTest.java
@@ -251,4 +251,219 @@ public class OAuth1SignerTest {
         //return new Base64.getEncoder().encodeToString(signatureBytes);
         return Base64.getEncoder().encodeToString(signatureBytes);
     }
+
+    @Test
+    public void test_OAuth1Signer_query_parameter_parsing() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        this.clockCurrentTimeMillis = 1600000000000L;
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1", null);
+        String signatureWithQueryParams0 = httpRequest.getAuthorizationHeader();
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?format=jpg", null);
+        String signatureWithQueryParams1 = httpRequest.getAuthorizationHeader();
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?format=jpg&key1=value1", null);
+        String signatureWithQueryParams2 = httpRequest.getAuthorizationHeader();
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?format=jpg&key1=value1&empty", null);
+        String signatureWithQueryParams3 = httpRequest.getAuthorizationHeader();
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?format=jpg&key1=value1&key1=value2", null);
+        String signatureWithQueryParams4 = httpRequest.getAuthorizationHeader();
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?key1=value2&format=jpg&key1=value1", null);
+        String signatureWithQueryParams5 = httpRequest.getAuthorizationHeader();
+        assertTrue(!signatureWithQueryParams0.equals(signatureWithQueryParams1));
+        assertTrue(!signatureWithQueryParams1.equals(signatureWithQueryParams2));
+        assertTrue(!signatureWithQueryParams2.equals(signatureWithQueryParams3));
+        assertTrue(!signatureWithQueryParams3.equals(signatureWithQueryParams4));
+        assertTrue(signatureWithQueryParams4.equals(signatureWithQueryParams5));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_query_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?format=jpg", null);
+        String signatureWithQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"K%2BnbO5%2Bvci0capErAT%2FzRN9A3mNSDWa%2BZFnt5RTt32w%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithQueryParams doesn't match expectedSignature", signatureWithQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_encoded_query_parameters1() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?" + "label=" + URLEncoder.encode("enabled;title=value", "UTF8"), null);
+        String signatureWithEncodedQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"C%2B%2FJibFgx%2F4KmGUbpe34hMWOxjsEqMXaTmxFRIP1QXo%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithEncodedQueryParams doesn't match expectedSignature", signatureWithEncodedQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_RFC_3986_unreserved_chars_in_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        // Testing RFC specification: Characters in the unreserved character set as defined by
+        // [RFC3986], Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST
+        // NOT be encoded.
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?" + "test=" + URLEncoder.encode("abcdefghijklmnopqrstuvwxyzABCDEFGHIJLKMNOPQRSTUVWXYZ0123456789-._~", "UTF8"), null);
+        String signatureWithUnreservedCharsInQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"rQHj8aDUX6CHIDRNaKXGcx2BsrS%2BOUWm5LlOWp7A7Ro%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithUnreservedCharsInQuery doesn't match expectedSignature", signatureWithUnreservedCharsInQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_star_in_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        // Testing RFC specification: Characters in the unreserved character set as defined by
+        // [RFC3986], Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST
+        // NOT be encoded.
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?" + "test=" + URLEncoder.encode("*", "UTF8"), null);
+        String signatureWithStarInQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"dKpGZp4Wc%2B56o4btchNf%2B5XrteuGfrSvVTZ5PeS%2FBZ0%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithStarInQueryParams doesn't match expectedSignature", signatureWithStarInQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_tilde_in_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        // Testing RFC specification: Characters in the unreserved character set as defined by
+        // [RFC3986], Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST
+        // NOT be encoded.
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?" + "test=" + URLEncoder.encode("~", "UTF8"), null);
+        String signatureWithTildeInQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"49m1vUzdoVt2LZ68hYXXdOJEl6BsKR3owS%2BJf2UHO0o%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithTildeInQueryParams doesn't match expectedSignature", signatureWithTildeInQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_space_in_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        // Testing RFC specification: Characters in the unreserved character set as defined by
+        // [RFC3986], Section 2.3 (ALPHA, DIGIT, "-", ".", "_", "~") MUST
+        // NOT be encoded.
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?" + "label=" + URLEncoder.encode("A test", "UTF8"), null);
+        String signatureWithSpaceInQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"bBfpwVDoyLN681mJH4628hVyyiRPPOmQDv%2BGILY4874%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithSpaceInQueryParams doesn't match expectedSignature", signatureWithSpaceInQueryParams.equals(expectedSignature));
+    }
+
+
+    @Test
+    public void test_OAuth1Signer_with_novalue_query_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?flag1&flag2&flag3=", null);
+        String signatureWithNoValueQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"mf6ZGeusZTqh1EaNgsGDQVzHV9TTvcKz5pE%2BW2f55XY%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithNoValueQueryParams doesn't match expectedSignature", signatureWithNoValueQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_encoded_key_in_query_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?" + URLEncoder.encode("key with spaces", "UTF8"), null);
+        String signatureWithEncodedKeyQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"n3E4mBpUd2DP%2FA9ekZsJODYiet5Gg7lhblnvRj3U8bo%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithEncodedKeyQueryParams doesn't match expectedSignature", signatureWithEncodedKeyQueryParams.equals(expectedSignature));
+    }
+
+    @Test
+    public void test_OAuth1Signer_with_value_in_query_parameters() throws UnsupportedEncodingException, InvalidKeyException, NoSuchAlgorithmException {
+        // oauth_timestamp = "1600000000"
+        this.clockCurrentTimeMillis = 1600000000000L;
+        byte[] nonceBytes = {
+                0x00,
+                0x01,
+                0x02,
+                0x03,
+                0x04,
+                0x05
+        };
+        // oauth_nonce = "AAECAw"
+        String nonce = Base64.getUrlEncoder().withoutPadding().encodeToString(nonceBytes).substring(0, nonceBytes.length);
+        oauth1Signer.authorize(httpRequest, "GET", "http://example.com/photos/photo1?=valueOnly", null);
+        String signatureWithValueOnlyInQueryParams = httpRequest.getAuthorizationHeader();
+        String expectedSignature = "OAuth oauth_consumer_key=\"access-key-id\", oauth_signature_method=\"HMAC-SHA256\", oauth_signature=\"IWx3kZAwS%2B%2Ba90pYRXvzJg0TkCK6D0FPf%2FCNzu5wK88%3D\", oauth_timestamp=\"1600000000\", oauth_nonce=\"AAECAw\", oauth_version=\"1.0\"";
+        assertTrue("signatureWithValueOnlyInQueryParams doesn't match expectedSignature", signatureWithValueOnlyInQueryParams.equals(expectedSignature));
+    }
 }


### PR DESCRIPTION
Added support to parse query parameters from URL so they can be used for OAuth1 signature
calculation. Also updated the encoder method to use RFC-5849 compliant unreserved characters
when constructing the OAuth1 base string (specifically the star and tilde characters).