### PR TITLE
Improve dependency convergence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,6 +108,12 @@
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${apache.httpclient.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>commons-logging</groupId>
+                        <artifactId>commons-logging</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>net.lightbody.bmp</groupId>


### PR DESCRIPTION
Exclude commons-logging:commons-logging:1.2 from the project in favour of 1.3.5 to resolve issues like:
~~~
[WARNING] 
Dependency convergence error for commons-logging:commons-logging:1.3.5 paths to dependency are:
+-com.here.platform.data.local:local-dataservice_2.12:0.8-SNAPSHOT
  +-com.here.account:here-oauth-client:0.4.30
    +-org.apache.commons:commons-configuration2:2.12.0
      +-commons-logging:commons-logging:1.3.5
and
+-com.here.platform.data.local:local-dataservice_2.12:0.8-SNAPSHOT
  +-com.here.account:here-oauth-client:0.4.30
    +-org.apache.httpcomponents:httpclient:4.5.14
      +-commons-logging:commons-logging:1.2
~~~

`commons-logging:commons-logging:1.3.5` declared explicitly at https://github.com/heremaps/here-aaa-java-sdk/blob/master/pom.xml#L199 