### PR TITLE
RefreshableResponseProvider.shutdown without waiting for queued tasks

### DIFF
--- a/here-oauth-client/src/main/java/com/here/account/util/RefreshableResponseProvider.java
+++ b/here-oauth-client/src/main/java/com/here/account/util/RefreshableResponseProvider.java
@@ -199,13 +199,13 @@ public class RefreshableResponseProvider<T extends ExpiringResponse> {
   }
   
   /**
-   * Shutdown the background threads
+   * Shutdown the background threads without waiting for queued tasks
    */
   public void shutdown() {
     if (started) {
       try {
         LOG.info("Shutting down refresh token thread");
-        scheduledExecutorService.shutdown();
+        scheduledExecutorService.shutdownNow();
       } finally {
         started = false;
       }


### PR DESCRIPTION
In many of our unit tests we involve instances of
`RefreshableResponseProvider`.

Problem is, we run into the issue of a large number of pending threads not being shutdown after test execution. This leads to OutOfMemoryExceptions during test runs, especially on MacOS systems.

The root cause is the `RefreshableResponseProvider`'s executor service "here-auth-refresher" thread is never being shutdown really, because there is always a refresh task waiting in the queue, usually.

This commit forces the `RefreshableResponseProvider`'s executor service to shutdown without waiting for the task queue to deplete. In local tests, this change nicely cleans up all refresher threads.